### PR TITLE
Add order import feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__/
+database.db
+uploads/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 Flask-SQLAlchemy
+openpyxl

--- a/templates/import_mapping.html
+++ b/templates/import_mapping.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Сопоставление столбцов</h2>
+<form method="post" action="{{ url_for('import_orders_finish') }}">
+  <input type="hidden" name="file_id" value="{{ file_id }}">
+  <div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" id="headerCheck" name="header" {% if header %}checked{% endif %}>
+    <label class="form-check-label" for="headerCheck">Первая строка содержит заголовки</label>
+  </div>
+  {% set fields = [('order_number','Номер заказа'), ('client_name','Имя клиента'), ('phone','Телефон'), ('address','Адрес')] %}
+  {% for field,label in fields %}
+  <div class="mb-3">
+    <label class="form-label">{{ label }}</label>
+    <select class="form-select" name="{{ field }}">
+      <option value="">-- Не использовать --</option>
+      {% for col in columns %}
+      <option value="{{ col.index }}">{{ col.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  {% endfor %}
+  <button type="submit" class="btn btn-primary">Импортировать</button>
+</form>
+{% endblock %}

--- a/templates/import_result.html
+++ b/templates/import_result.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Импорт завершен</h2>
+<p>Импортировано заказов: {{ count }}</p>
+<a class="btn btn-primary" href="{{ url_for('orders') }}">К списку заказов</a>
+{% endblock %}

--- a/templates/import_upload.html
+++ b/templates/import_upload.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Импорт заказов</h2>
+<form method="post" enctype="multipart/form-data">
+  <div class="mb-3">
+    <input class="form-control" type="file" name="file" accept=".csv,.xlsx">
+  </div>
+  <button type="submit" class="btn btn-primary">Загрузить</button>
+</form>
+{% endblock %}

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Заказы</h2>
+<a class="btn btn-sm btn-success mb-3" href="{{ url_for('import_orders') }}">Импорт заказов</a>
 <table class="table table-striped">
     <thead>
         <tr>


### PR DESCRIPTION
## Summary
- support uploading CSV or Excel with `openpyxl`
- add column mapping step and optional header row
- generate order number automatically if absent
- store imported orders and detect zone
- add pages for uploading, mapping and result
- ignore DB artifacts

## Testing
- `pip install openpyxl Flask Flask-SQLAlchemy --no-warn-script-location`
- `python -m py_compile app.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_68512a9d2e74832cbcfe2debbb5768ea