### PR TITLE
Add order editing modal

### DIFF
--- a/models.py
+++ b/models.py
@@ -11,6 +11,7 @@ class Order(db.Model):
     client_name = db.Column(db.String(120), nullable=False)
     phone = db.Column(db.String(64))
     address = db.Column(db.String(256))
+    note = db.Column(db.Text)
     status = db.Column(db.String(64), default="Складская обработка")
     latitude = db.Column(db.Float)
     longitude = db.Column(db.Float)

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,6 +26,18 @@
   </div>
 </nav>
 <div class="container">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+    <div class="mt-2">
+        {% for category, message in messages %}
+        <div class="alert alert-{{ 'warning' if category=='warning' else 'success' }} alert-dismissible fade show" role="alert">
+            {{ message }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
+    {% endwith %}
     {% block content %}{% endblock %}
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -13,7 +13,7 @@
             <th>Статус</th>
             <th>Координаты</th>
             <th>Зона</th>
-            <th></th>
+            <th>Действия</th>
         </tr>
     </thead>
     <tbody>
@@ -37,6 +37,43 @@
             </td>
             <td>{% if o.latitude and o.longitude %}✔{% else %}✘{% endif %}</td>
             <td>{{ o.zone or '' }}</td>
+            <td>
+                <button class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#editModal{{ o.id }}">Редактировать</button>
+                <div class="modal fade" id="editModal{{ o.id }}" tabindex="-1" aria-hidden="true">
+                  <div class="modal-dialog">
+                    <div class="modal-content">
+                      <form method="post" action="{{ url_for('update_order', order_id=o.id) }}">
+                        <div class="modal-header">
+                          <h5 class="modal-title">Редактирование заказа {{ o.order_number }}</h5>
+                          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+                          <div class="mb-3">
+                            <label class="form-label">Имя клиента</label>
+                            <input type="text" class="form-control" name="client_name" value="{{ o.client_name }}">
+                          </div>
+                          <div class="mb-3">
+                            <label class="form-label">Телефон</label>
+                            <input type="text" class="form-control" name="phone" value="{{ o.phone }}">
+                          </div>
+                          <div class="mb-3">
+                            <label class="form-label">Адрес</label>
+                            <input type="text" class="form-control" name="address" value="{{ o.address }}">
+                          </div>
+                          <div class="mb-3">
+                            <label class="form-label">Заметка</label>
+                            <textarea class="form-control" name="note">{{ o.note or '' }}</textarea>
+                          </div>
+                        </div>
+                        <div class="modal-footer">
+                          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button>
+                          <button type="submit" class="btn btn-primary">Сохранить</button>
+                        </div>
+                      </form>
+                    </div>
+                  </div>
+                </div>
+            </td>
         </tr>
         {% endfor %}
     </tbody>


### PR DESCRIPTION
## Summary
- enable editing orders from the orders table
- support `note` field in the model
- re-geocode address on edit and detect zone
- show success and warning messages

## Testing
- `python -m py_compile app.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_68512bea82b0832cad75a6ef959c7c15