### PR TITLE
Add manual coordinate setting for orders

### DIFF
--- a/app.py
+++ b/app.py
@@ -139,6 +139,27 @@ def update_order(order_id):
     flash('Заказ обновлен', 'success')
     return redirect(url_for('orders'))
 
+@app.route('/orders/<int:order_id>/set_coords', methods=['GET', 'POST'])
+@login_required
+def set_coords(order_id):
+    order = Order.query.get_or_404(order_id)
+    if request.method == 'POST':
+        lat = request.form.get('latitude')
+        lng = request.form.get('longitude')
+        try:
+            lat = float(lat)
+            lng = float(lng)
+        except (TypeError, ValueError):
+            flash('Некорректные координаты', 'warning')
+            return redirect(url_for('set_coords', order_id=order_id))
+        order.latitude = lat
+        order.longitude = lng
+        order.zone = detect_zone(lat, lng)
+        db.session.commit()
+        flash('Координаты сохранены', 'success')
+        return redirect(url_for('orders'))
+    return render_template('set_coords.html', order=order)
+
 
 @app.route('/map')
 @login_required

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -35,7 +35,7 @@
                     <button type="submit" class="btn btn-sm btn-primary">OK</button>
                 </form>
             </td>
-            <td>{% if o.latitude and o.longitude %}✔{% else %}✘{% endif %}</td>
+            <td>{% if o.latitude and o.longitude %}✔{% else %}✘ <a href="{{ url_for('set_coords', order_id=o.id) }}" class="btn btn-sm btn-outline-primary ms-2">Установить на карте</a>{% endif %}</td>
             <td>{{ o.zone or '—' }}</td>
             <td>
                 <button class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#editModal{{ o.id }}">Редактировать</button>

--- a/templates/set_coords.html
+++ b/templates/set_coords.html
@@ -1,0 +1,42 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Установка координат для заказа {{ order.order_number }}</h2>
+<form method="post">
+  <div id="map" style="height:400px;" class="mb-3"></div>
+  <input type="hidden" name="latitude" id="latitude">
+  <input type="hidden" name="longitude" id="longitude">
+  <button type="submit" class="btn btn-primary" id="saveBtn" disabled>Сохранить</button>
+  <a href="{{ url_for('orders') }}" class="btn btn-secondary">Отмена</a>
+</form>
+{% endblock %}
+{% block scripts %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
+<script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
+<script>
+var map = L.map('map').setView([55.75, 37.65], 11);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+var marker = null;
+function updateMarker(latlng) {
+    if (marker) {
+        map.removeLayer(marker);
+    }
+    marker = L.marker(latlng).addTo(map);
+    document.getElementById('latitude').value = latlng.lat;
+    document.getElementById('longitude').value = latlng.lng;
+    document.getElementById('saveBtn').disabled = false;
+}
+var initLat = {{ order.latitude or 'null' }};
+var initLng = {{ order.longitude or 'null' }};
+if (initLat && initLng) {
+    var latlng = L.latLng(initLat, initLng);
+    updateMarker(latlng);
+    map.setView(latlng, 13);
+}
+map.on('click', function(e){
+    updateMarker(e.latlng);
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow orders to have coordinates manually set
- show a button near orders without coordinates
- add Leaflet page to pick coordinates and save to DB

## Testing
- `python -m py_compile app.py models.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68512e1d6b30832ca6b575e7aa4c44f9