### PR TITLE
Add delivery history with Excel export

### DIFF
--- a/models.py
+++ b/models.py
@@ -16,6 +16,7 @@ class Order(db.Model):
     latitude = db.Column(db.Float)
     longitude = db.Column(db.Float)
     zone = db.Column(db.String(64))
+    delivered_at = db.Column(db.Date)
 
 
 class DeliveryZone(db.Model):

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,6 +17,7 @@
         <li class="nav-item"><a class="nav-link" href="{{ url_for('map_view') }}">Карта</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('zones') }}">Зоны</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('couriers') }}">Курьеры</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('history') }}">История</a></li>
       </ul>
       {% if session.get('user') %}
         <span class="navbar-text me-3">{{ session['user'] }}</span>

--- a/templates/history.html
+++ b/templates/history.html
@@ -1,0 +1,42 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>История доставок</h2>
+<form method="get" class="mb-3 d-flex align-items-end">
+  <div class="me-2">
+    <label class="form-label">Период</label>
+    <select name="period" class="form-select">
+      <option value="today" {% if period=='today' %}selected{% endif %}>Сегодня</option>
+      <option value="7" {% if period=='7' %}selected{% endif %}>Последние 7 дней</option>
+      <option value="month" {% if period=='month' %}selected{% endif %}>Последний месяц</option>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary me-2">Применить</button>
+  <a class="btn btn-success" href="{{ url_for('export_history', period=period) }}">Экспорт в Excel</a>
+</form>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>№</th>
+      <th>Клиент</th>
+      <th>Телефон</th>
+      <th>Адрес</th>
+      <th>Дата</th>
+      <th>Зона доставки</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for o in orders %}
+    <tr>
+      <td>{{ o.id }}</td>
+      <td>{{ o.order_number }}</td>
+      <td>{{ o.client_name }}</td>
+      <td>{{ o.phone }}</td>
+      <td>{{ o.address }}</td>
+      <td>{{ o.delivered_at or '' }}</td>
+      <td>{{ o.zone or '—' }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- track when orders are delivered
- add `/history` page to view delivered orders
- filter delivered orders by period
- export filtered deliveries to Excel
- link history page from navbar

## Testing
- `python -m py_compile app.py models.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6851304ccddc832c9e05ef6dcef66647