### PR TITLE
Add delivery stats page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -18,6 +18,7 @@
         <li class="nav-item"><a class="nav-link" href="{{ url_for('zones') }}">Зоны</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('couriers') }}">Курьеры</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('history') }}">История</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('stats') }}">Статистика</a></li>
       </ul>
       {% if session.get('user') %}
         <span class="navbar-text me-3">{{ session['user'] }}</span>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -1,0 +1,89 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Статистика доставок</h2>
+<form class="row g-2 mb-3" id="filters">
+  <div class="col-auto">
+    <label class="form-label">Период</label>
+    <select id="period" class="form-select">
+      <option value="today">Сегодня</option>
+      <option value="week">Неделя</option>
+      <option value="month">Месяц</option>
+      <option value="all">Все</option>
+    </select>
+  </div>
+  <div class="col-auto">
+    <label class="form-label">Зона</label>
+    <select id="zone" class="form-select">
+      <option value="">Все</option>
+      {% for z in zones %}
+      <option value="{{ z.name }}">{{ z.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-auto">
+    <label class="form-label">Курьер</label>
+    <select id="courier" class="form-select">
+      <option value="">Все</option>
+      {% for c in couriers %}
+      <option value="{{ c.id }}">{{ c.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-auto align-self-end">
+    <button class="btn btn-primary" id="applyFilters">Применить</button>
+  </div>
+</form>
+<canvas id="ordersChart" height="100"></canvas>
+<canvas id="zoneChart" height="100" class="mt-4"></canvas>
+{% endblock %}
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function(){
+  let lineChart, pieChart;
+  function loadData(){
+    const params = new URLSearchParams();
+    params.append('period', document.getElementById('period').value);
+    const zone = document.getElementById('zone').value;
+    if(zone) params.append('zone', zone);
+    const courier = document.getElementById('courier').value;
+    if(courier) params.append('courier', courier);
+    fetch('{{ url_for('stats_data') }}?' + params.toString())
+      .then(r => r.json())
+      .then(updateCharts);
+  }
+  function updateCharts(data){
+    const ctx = document.getElementById('ordersChart').getContext('2d');
+    if(lineChart) lineChart.destroy();
+    lineChart = new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: data.dates,
+        datasets: [{
+          label: 'Доставленные заказы',
+          data: data.counts,
+          borderColor: 'rgb(75,192,192)',
+          tension: 0.1
+        }]
+      }
+    });
+    const pctx = document.getElementById('zoneChart').getContext('2d');
+    if(pieChart) pieChart.destroy();
+    pieChart = new Chart(pctx, {
+      type: 'pie',
+      data: {
+        labels: data.zone_labels,
+        datasets: [{
+          data: data.zone_counts
+        }]
+      }
+    });
+  }
+  document.getElementById('applyFilters').addEventListener('click', function(e){
+    e.preventDefault();
+    loadData();
+  });
+  loadData();
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `/stats` page with Chart.js graphs
- serve data via `/stats/data`
- link new page in navbar

## Testing
- `python -m py_compile app.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_6851328d721c832ca346dd8ad2d4725e