### PR TITLE
Add zone editing and automatic courier assignment

### DIFF
--- a/models.py
+++ b/models.py
@@ -20,6 +20,8 @@ class Order(db.Model):
     delivered_at = db.Column(db.Date)
     comment = db.Column(db.Text)
     photo_filename = db.Column(db.String(128))
+    courier_id = db.Column(db.Integer, db.ForeignKey('couriers.id'))
+    courier = db.relationship('Courier', backref='orders')
 
 
 class DeliveryZone(db.Model):

--- a/templates/edit_zone.html
+++ b/templates/edit_zone.html
@@ -1,0 +1,52 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Редактирование зоны {{ zone.name }}</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Название</label>
+    <input type="text" class="form-control" name="name" value="{{ zone.name }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Цвет</label>
+    <input type="color" class="form-control form-control-color" id="colorInput" name="color" value="{{ zone.color }}">
+  </div>
+  <div id="map" style="height:400px;" class="mb-3"></div>
+  <input type="hidden" name="polygon" id="polygonInput">
+  <button type="submit" class="btn btn-primary">Сохранить</button>
+  <a href="{{ url_for('zones') }}" class="btn btn-secondary">Отмена</a>
+  <button id="resetBtn" class="btn btn-warning float-end">Очистить</button>
+</form>
+{% endblock %}
+{% block scripts %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
+<script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
+<script>
+var polygonCoords = {{ zone.polygon_json|tojson }};
+var colorInput = document.getElementById('colorInput');
+var map = L.map('map').setView([polygonCoords[0][1], polygonCoords[0][0]], 12);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+var poly = null;
+function updatePolygon(){
+    if(poly){map.removeLayer(poly);}
+    if(polygonCoords.length){
+        poly = L.polygon(polygonCoords.map(function(p){return [p[1],p[0]];}), {color: colorInput.value}).addTo(map);
+        map.fitBounds(poly.getBounds());
+    }
+    document.getElementById('polygonInput').value = JSON.stringify(polygonCoords);
+}
+map.on('click', function(e){
+    polygonCoords.push([e.latlng.lng, e.latlng.lat]);
+    updatePolygon();
+});
+document.getElementById('resetBtn').addEventListener('click', function(e){
+    e.preventDefault();
+    polygonCoords = [];
+    updatePolygon();
+});
+colorInput.addEventListener('change', updatePolygon);
+updatePolygon();
+</script>
+{% endblock %}

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -15,6 +15,7 @@
             <th>Статус</th>
             <th>Координаты</th>
             <th>Зона доставки</th>
+            <th>Курьер</th>
             <th>Комментарий / Фото</th>
             <th>Действия</th>
         </tr>
@@ -50,6 +51,7 @@
             </td>
             <td>{% if o.latitude and o.longitude %}✔{% else %}✘ <a href="{{ url_for('set_coords', order_id=o.id) }}" class="btn btn-sm btn-outline-primary ms-2">Установить на карте</a>{% endif %}</td>
             <td>{{ o.zone or '—' }}</td>
+            <td>{{ o.courier.name if o.courier else '—' }}</td>
             <td>
                 {% if o.comment %}<div>{{ o.comment }}</div>{% endif %}
                 {% if o.photo_filename %}
@@ -111,6 +113,15 @@
                           <div class="mb-3">
                             <label class="form-label">Заметка</label>
                             <textarea class="form-control" name="note">{{ o.note or '' }}</textarea>
+                          </div>
+                          <div class="mb-3">
+                            <label class="form-label">Курьер</label>
+                            <select class="form-select" name="courier_id">
+                              <option value="">Авто</option>
+                              {% for c in couriers %}
+                              <option value="{{ c.id }}" {% if o.courier_id==c.id %}selected{% endif %}>{{ c.name }}</option>
+                              {% endfor %}
+                            </select>
                           </div>
                         </div>
                         <div class="modal-footer">

--- a/templates/zones.html
+++ b/templates/zones.html
@@ -3,11 +3,19 @@
 <h2>Зоны доставки</h2>
 <table class="table table-striped mb-3">
     <thead>
-        <tr><th>ID</th><th>Название</th><th>Цвет</th></tr>
+        <tr><th>ID</th><th>Название</th><th>Цвет</th><th></th></tr>
     </thead>
     <tbody>
     {% for z in zones %}
-    <tr><td>{{ z.id }}</td><td>{{ z.name }}</td><td><span style="background:{{ z.color }};padding:2px 10px;display:inline-block;"></span> {{ z.color }}</td></tr>
+    <tr>
+      <td>{{ z.id }}</td>
+      <td>{{ z.name }}</td>
+      <td><span style="background:{{ z.color }};padding:2px 10px;display:inline-block;"></span> {{ z.color }}</td>
+      <td>
+        <a class="btn btn-sm btn-primary" href="{{ url_for('edit_zone', zone_id=z.id) }}">Редактировать</a>
+        <a class="btn btn-sm btn-danger" href="{{ url_for('delete_zone', zone_id=z.id) }}" onclick="return confirm('Удалить зону?');">Удалить</a>
+      </td>
+    </tr>
     {% endfor %}
     </tbody>
 </table>


### PR DESCRIPTION
## Summary
- allow admins to edit or delete delivery zones
- show Leaflet editor for zone polygons
- link orders with couriers by zone with manual override
- display courier column in orders table

## Testing
- `python -m py_compile app.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_685136cda59c832c9c1ade863d299962