### PR TITLE
Add Nominatim geocoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ python app.py
 ```
 
 On first start demo data will be generated automatically. Configuration values can be changed in `config.py` or via environment variables.
+\nThe application uses OpenStreetMap Nominatim for geocoding. Requests are limited to one per second.

--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from config import Config
 from sqlalchemy import func
 import openpyxl
 from io import BytesIO
+from geocode import geocode_address
 
 app = Flask(__name__)
 app.config.from_object(Config)
@@ -76,12 +77,6 @@ def assign_courier_for_zone(zone_name):
             if zone_name in zones:
                 return c
     return None
-
-
-def geocode(address):
-    """Placeholder geocoder returning None coordinates."""
-    return None, None
-
 
 def populate_demo_data():
     """Populate database with demo zones, couriers and orders."""
@@ -202,7 +197,7 @@ def update_order(order_id):
     order.address = request.form.get('address', order.address)
     order.note = request.form.get('note', order.note)
     if order.address != old_address:
-        lat, lng = geocode(order.address)
+        lat, lng = geocode_address(order.address)
         order.latitude = lat
         order.longitude = lng
         if lat and lng:
@@ -458,7 +453,7 @@ def import_orders_finish():
         phone = ''
         if mapping['phone'] is not None and mapping['phone'] < len(r):
             phone = str(r[mapping['phone']]).strip()
-        lat, lng = geocode(address)
+        lat, lng = geocode_address(address)
         zone = detect_zone(lat, lng) if lat and lng else None
         order = Order(order_number=order_number,
                       client_name=client_name,

--- a/geocode.py
+++ b/geocode.py
@@ -1,0 +1,40 @@
+import requests
+import time
+
+_last_request_time = 0
+
+
+def geocode_address(address: str):
+    """Return latitude and longitude for address using Nominatim."""
+    global _last_request_time
+    if not address:
+        return None, None
+    # ensure no more than 1 request per second
+    now = time.time()
+    elapsed = now - _last_request_time
+    if elapsed < 1:
+        time.sleep(1 - elapsed)
+    params = {
+        "q": address,
+        "format": "json",
+        "limit": 1,
+    }
+    headers = {"User-Agent": "delivery_crm_app"}
+    try:
+        resp = requests.get(
+            "https://nominatim.openstreetmap.org/search",
+            params=params,
+            headers=headers,
+            timeout=10,
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            if data:
+                lat = float(data[0]["lat"])
+                lon = float(data[0]["lon"])
+                _last_request_time = time.time()
+                return lat, lon
+    except Exception:
+        pass
+    _last_request_time = time.time()
+    return None, None

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask
 Flask-SQLAlchemy
 openpyxl
 Flask-Login
+requests


### PR DESCRIPTION
## Summary
- fetch coordinates from Nominatim with a `geocode_address` helper
- use real geocoding when importing orders or editing an address
- document geocoding usage in README
- require `requests`

## Testing
- `python -m py_compile app.py geocode.py models.py config.py`
- `pip install --break-system-packages -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68513a5b5ee8832cbd8f8bd0fa525fef