### PR TITLE
Implement root route redirect in Flask CRM

### DIFF
--- a/app.py
+++ b/app.py
@@ -134,6 +134,14 @@ with app.app_context():
     populate_demo_data()
 
 
+@app.route('/')
+def index():
+    if current_user.is_authenticated:
+        return redirect(url_for('orders'))
+    else:
+        return redirect(url_for('login'))
+
+
 @app.route('/login', methods=['GET', 'POST'])
 def login():
     if request.method == 'POST':


### PR DESCRIPTION
## Summary
- redirect `/` to `/orders` when logged in and to `/login` otherwise

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails before installing dependencies)*
- `pip install -q Flask Flask-SQLAlchemy openpyxl Flask-Login requests`
- `python app.py` *(runs server)*
- `python - <<'PY'
from app import app
app.testing=True
client=app.test_client()
print(client.get('/', follow_redirects=False).status_code, client.get('/', follow_redirects=False).headers.get('Location'))
with client:
    client.post('/login', data={'username':'admin','password':'admin'})
    r=client.get('/', follow_redirects=False)
    print(r.status_code, r.headers.get('Location'))
PY
`

------
https://chatgpt.com/codex/tasks/task_e_68513efbdc6c832c851f36ed9f01741a