### PR TITLE
Add sidebar navigation and user management

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,1 +1,4 @@
-body { padding-top: 20px; }
+body { padding-top: 0; }
+@media (min-width:768px){
+  #sidebarMenu + .flex-grow-1 { margin-left: 220px; }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,49 +8,92 @@
     <title>Delivery CRM</title>
 </head>
 <body>
-<nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
+{% if current_user.is_authenticated %}
+<div class="d-flex">
+  <nav id="sidebarMenu" class="d-none d-md-flex flex-column flex-shrink-0 p-3 bg-light position-fixed" style="width:220px;height:100vh;">
+    <a class="fs-4 text-decoration-none mb-3" href="{{ url_for('orders') }}">CRM</a>
+    <ul class="nav nav-pills flex-column mb-auto">
+      <li class="nav-item"><a class="nav-link" href="{{ url_for('orders') }}">Заказы</a></li>
+      <li><a class="nav-link" href="{{ url_for('map_view') }}">Карта заказов</a></li>
+      {% if current_user.role == 'admin' %}
+      <li><a class="nav-link" href="{{ url_for('zones') }}">Зоны доставки</a></li>
+      <li><a class="nav-link" href="{{ url_for('users') }}">Пользователи</a></li>
+      <li><a class="nav-link" href="{{ url_for('stats') }}">Статистика</a></li>
+      {% endif %}
+    </ul>
+    <div class="mt-auto">
+      <span class="d-block mb-2">{{ current_user.username }}</span>
+      <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('logout') }}">Выход</a>
+    </div>
+  </nav>
+
+  <div class="offcanvas offcanvas-start" tabindex="-1" id="offcanvasMenu">
+    <div class="offcanvas-header">
+      <h5 class="offcanvas-title">CRM</h5>
+      <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    </div>
+    <div class="offcanvas-body">
+      <ul class="nav nav-pills flex-column mb-auto">
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('orders') }}">Заказы</a></li>
+        <li><a class="nav-link" href="{{ url_for('map_view') }}">Карта заказов</a></li>
+        {% if current_user.role == 'admin' %}
+        <li><a class="nav-link" href="{{ url_for('zones') }}">Зоны доставки</a></li>
+        <li><a class="nav-link" href="{{ url_for('users') }}">Пользователи</a></li>
+        <li><a class="nav-link" href="{{ url_for('stats') }}">Статистика</a></li>
+        {% endif %}
+        <li class="mt-3"><a class="btn btn-sm btn-outline-secondary w-100" href="{{ url_for('logout') }}">Выход</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="flex-grow-1" style="margin-left:220px;">
+    <nav class="navbar navbar-light bg-light d-md-none">
+      <div class="container-fluid">
+        <button class="btn btn-primary" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasMenu">☰</button>
+        <span class="navbar-brand ms-2">CRM</span>
+        <span class="ms-auto me-2">{{ current_user.username }}</span>
+        <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('logout') }}">Выход</a>
+      </div>
+    </nav>
+    <div class="container-fluid pt-3">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+      <div class="mt-2">
+        {% for category, message in messages %}
+        <div class="alert alert-{{ 'warning' if category=='warning' else 'success' }} alert-dismissible fade show" role="alert">
+          {{ message }}
+          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+        {% endfor %}
+      </div>
+      {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </div>
+  </div>
+</div>
+{% else %}
+<nav class="navbar navbar-light bg-light mb-3">
   <div class="container-fluid">
     <a class="navbar-brand" href="#">CRM</a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarMenu" aria-controls="navbarMenu" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarMenu">
-      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        {% if current_user.is_authenticated %}
-          <li class="nav-item"><a class="nav-link" href="{{ url_for('orders') }}">Заказы</a></li>
-          <li class="nav-item"><a class="nav-link" href="{{ url_for('map_view') }}">Карта</a></li>
-          {% if current_user.role == 'admin' %}
-            <li class="nav-item"><a class="nav-link" href="{{ url_for('zones') }}">Зоны</a></li>
-            <li class="nav-item"><a class="nav-link" href="{{ url_for('couriers') }}">Курьеры</a></li>
-            <li class="nav-item"><a class="nav-link" href="{{ url_for('history') }}">История</a></li>
-            <li class="nav-item"><a class="nav-link" href="{{ url_for('stats') }}">Статистика</a></li>
-          {% endif %}
-        {% endif %}
-      </ul>
-      {% if current_user.is_authenticated %}
-        <span class="navbar-text me-3">{{ current_user.username }}</span>
-        <a class="btn btn-outline-secondary" href="{{ url_for('logout') }}">Выход</a>
-      {% else %}
-        <a class="btn btn-outline-primary" href="{{ url_for('login') }}">Вход</a>
-      {% endif %}
-    </div>
   </div>
 </nav>
 <div class="container">
-    {% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-    <div class="mt-2">
-        {% for category, message in messages %}
-        <div class="alert alert-{{ 'warning' if category=='warning' else 'success' }} alert-dismissible fade show" role="alert">
-            {{ message }}
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-        </div>
-        {% endfor %}
+  {% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+  <div class="mt-2">
+    {% for category, message in messages %}
+    <div class="alert alert-{{ 'warning' if category=='warning' else 'success' }} alert-dismissible fade show" role="alert">
+      {{ message }}
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
-    {% endif %}
-    {% endwith %}
-    {% block content %}{% endblock %}
+    {% endfor %}
+  </div>
+  {% endif %}
+  {% endwith %}
+  {% block content %}{% endblock %}
 </div>
+{% endif %}
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
 <script src="{{ url_for('static', filename='scripts.js') }}"></script>
 {% block scripts %}{% endblock %}

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -4,139 +4,140 @@
 {% if current_user.role == 'admin' %}
 <a class="btn btn-sm btn-success mb-3" href="{{ url_for('import_orders') }}">Импорт заказов</a>
 {% endif %}
-<div class="table-responsive">
-<table class="table table-striped">
-    <thead>
-        <tr>
-            <th>ID</th>
-            <th>№</th>
-            <th>Клиент</th>
-            <th>Телефон</th>
-            <th>Адрес</th>
-            <th>Статус</th>
-            <th>Координаты</th>
-            <th>Зона доставки</th>
-            <th>Курьер</th>
-            <th>Комментарий / Фото</th>
-            <th>Действия</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for o in orders %}
-        <tr>
+<ul class="nav nav-tabs mb-3" id="ordersTabs" role="tablist">
+  <li class="nav-item" role="presentation"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tabAll" type="button">Все</button></li>
+  <li class="nav-item" role="presentation"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabZones" type="button">По зонам</button></li>
+</ul>
+<div class="tab-content">
+  <div class="tab-pane fade show active" id="tabAll">
+    <div class="table-responsive">
+      <table class="table table-striped">
+        <thead>
+          <tr><th>ID</th><th>№</th><th>Клиент</th><th>Телефон</th><th>Адрес</th><th>Статус</th><th>Координаты</th><th>Зона доставки</th><th>Курьер</th><th>Комментарий / Фото</th><th>Действия</th></tr>
+        </thead>
+        <tbody>
+          {% for o in orders %}
+          <tr data-id="{{ o.id }}" class="{% if not o.zone %}table-warning{% endif %}">
             <td>{{ o.id }}</td>
             <td>{{ o.order_number }}</td>
             <td>{{ o.client_name }}</td>
             <td>{{ o.phone }}</td>
             <td>{{ o.address }}</td>
             <td>
-                {% set status_class = {
-                    'Складская обработка': 'bg-secondary',
-                    'Подготовлен к доставке': 'bg-info',
-                    'Выдан': 'bg-warning',
-                    'Доставлен': 'bg-success'
-                } %}
-                <span class="badge {{ status_class.get(o.status, 'bg-secondary') }}">{{ o.status }}</span>
-                <button class="btn btn-sm btn-link p-0 ms-2" type="button" data-bs-toggle="collapse" data-bs-target="#statusForm{{ o.id }}">Изменить</button>
-                <div class="collapse mt-1" id="statusForm{{ o.id }}">
-                    <form method="post" class="d-flex">
-                        <input type="hidden" name="id" value="{{ o.id }}">
-                        <select name="status" class="form-select form-select-sm me-2">
-                            {% for st in ['Складская обработка', 'Подготовлен к доставке', 'Выдан', 'Доставлен'] %}
-                            <option value="{{ st }}" {% if o.status==st %}selected{% endif %}>{{ st }}</option>
-                            {% endfor %}
-                        </select>
-                        <button type="submit" class="btn btn-sm btn-primary">OK</button>
-                    </form>
-                </div>
+              {% set status_class = {
+                  'Складская обработка':'bg-secondary',
+                  'Подготовлен к доставке':'bg-info',
+                  'Выдан':'bg-warning',
+                  'Доставлен':'bg-success'
+              } %}
+              <span class="badge {{ status_class.get(o.status, 'bg-secondary') }}">{{ o.status }}</span>
+              <button class="btn btn-sm btn-link p-0 ms-2" type="button" data-bs-toggle="collapse" data-bs-target="#statusForm{{ o.id }}">Изменить</button>
+              <div class="collapse mt-1" id="statusForm{{ o.id }}">
+                <form method="post" class="d-flex">
+                  <input type="hidden" name="id" value="{{ o.id }}">
+                  <select name="status" class="form-select form-select-sm me-2">
+                    {% for st in ['Складская обработка','Подготовлен к доставке','Выдан','Доставлен'] %}
+                    <option value="{{ st }}" {% if o.status==st %}selected{% endif %}>{{ st }}</option>
+                    {% endfor %}
+                  </select>
+                  <button type="submit" class="btn btn-sm btn-primary">OK</button>
+                </form>
+              </div>
             </td>
-            <td>{% if o.latitude and o.longitude %}✔{% else %}✘ <a href="{{ url_for('set_coords', order_id=o.id) }}" class="btn btn-sm btn-outline-primary ms-2">Установить на карте</a>{% endif %}</td>
-            <td>{{ o.zone or '—' }}</td>
+            <td class="coords-cell">
+              {% if o.latitude and o.longitude %}✔{% else %}✘{% if not o.zone %} <button class="btn btn-sm btn-outline-primary set-point-btn" data-id="{{ o.id }}">Указать точку</button>{% else %} <a href="{{ url_for('set_coords', order_id=o.id) }}" class="btn btn-sm btn-outline-primary ms-2">Установить на карте</a>{% endif %}{% endif %}
+            </td>
+            <td class="zone-cell">{{ o.zone or 'Не определена' }}</td>
             <td>{{ o.courier.name if o.courier else '—' }}</td>
             <td>
-                {% if o.comment %}<div>{{ o.comment }}</div>{% endif %}
-                {% if o.photo_filename %}
-                <a href="{{ url_for('static', filename='uploads/' + o.photo_filename) }}" target="_blank">Фото</a>
-                {% endif %}
-                {% if current_user.role == 'courier' %}
-                <button class="btn btn-sm btn-link p-0 ms-2" type="button" data-bs-toggle="modal" data-bs-target="#commentModal{{ o.id }}">Добавить фото / комментарий</button>
-                <div class="modal fade" id="commentModal{{ o.id }}" tabindex="-1" aria-hidden="true">
-                  <div class="modal-dialog">
-                    <div class="modal-content">
-                      <form method="post" action="{{ url_for('add_comment_photo', order_id=o.id) }}" enctype="multipart/form-data">
-                        <div class="modal-header">
-                          <h5 class="modal-title">Комментарий для заказа {{ o.order_number }}</h5>
-                          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                        </div>
-                        <div class="modal-body">
-                          <div class="mb-3">
-                            <label class="form-label">Комментарий</label>
-                            <textarea class="form-control" name="comment"></textarea>
-                          </div>
-                          <div class="mb-3">
-                            <label class="form-label">Фото</label>
-                            <input type="file" class="form-control" name="photo" accept="image/jpeg,image/png">
-                          </div>
-                        </div>
-                        <div class="modal-footer">
-                          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button>
-                          <button type="submit" class="btn btn-primary">Сохранить</button>
-                        </div>
-                      </form>
-                    </div>
+              {% if o.comment %}<div>{{ o.comment }}</div>{% endif %}
+              {% if o.photo_filename %}<a href="{{ url_for('static', filename='uploads/' + o.photo_filename) }}" target="_blank">Фото</a>{% endif %}
+              {% if current_user.role == 'courier' %}
+              <button class="btn btn-sm btn-link p-0 ms-2" type="button" data-bs-toggle="modal" data-bs-target="#commentModal{{ o.id }}">Добавить фото / комментарий</button>
+              <div class="modal fade" id="commentModal{{ o.id }}" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog"><div class="modal-content"><form method="post" action="{{ url_for('add_comment_photo', order_id=o.id) }}" enctype="multipart/form-data">
+                  <div class="modal-header"><h5 class="modal-title">Комментарий для заказа {{ o.order_number }}</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+                  <div class="modal-body">
+                    <div class="mb-3"><label class="form-label">Комментарий</label><textarea class="form-control" name="comment"></textarea></div>
+                    <div class="mb-3"><label class="form-label">Фото</label><input type="file" class="form-control" name="photo" accept="image/jpeg,image/png"></div>
                   </div>
-                </div>
-                {% endif %}
+                  <div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button><button type="submit" class="btn btn-primary">Сохранить</button></div>
+                </form></div></div>
+              </div>
+              {% endif %}
             </td>
             <td>
-                <button class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#editModal{{ o.id }}">Редактировать</button>
-                <div class="modal fade" id="editModal{{ o.id }}" tabindex="-1" aria-hidden="true">
-                  <div class="modal-dialog">
-                    <div class="modal-content">
-                      <form method="post" action="{{ url_for('update_order', order_id=o.id) }}">
-                        <div class="modal-header">
-                          <h5 class="modal-title">Редактирование заказа {{ o.order_number }}</h5>
-                          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                        </div>
-                        <div class="modal-body">
-                          <div class="mb-3">
-                            <label class="form-label">Имя клиента</label>
-                            <input type="text" class="form-control" name="client_name" value="{{ o.client_name }}">
-                          </div>
-                          <div class="mb-3">
-                            <label class="form-label">Телефон</label>
-                            <input type="text" class="form-control" name="phone" value="{{ o.phone }}">
-                          </div>
-                          <div class="mb-3">
-                            <label class="form-label">Адрес</label>
-                            <input type="text" class="form-control" name="address" value="{{ o.address }}">
-                          </div>
-                          <div class="mb-3">
-                            <label class="form-label">Заметка</label>
-                            <textarea class="form-control" name="note">{{ o.note or '' }}</textarea>
-                          </div>
-                          <div class="mb-3">
-                            <label class="form-label">Курьер</label>
-                            <select class="form-select" name="courier_id">
-                              <option value="">Авто</option>
-                              {% for c in couriers %}
-                              <option value="{{ c.id }}" {% if o.courier_id==c.id %}selected{% endif %}>{{ c.name }}</option>
-                              {% endfor %}
-                            </select>
-                          </div>
-                        </div>
-                        <div class="modal-footer">
-                          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button>
-                          <button type="submit" class="btn btn-primary">Сохранить</button>
-                        </div>
-                      </form>
-                    </div>
+              <button class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#editModal{{ o.id }}">Редактировать</button>
+              <div class="modal fade" id="editModal{{ o.id }}" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog"><div class="modal-content"><form method="post" action="{{ url_for('update_order', order_id=o.id) }}">
+                  <div class="modal-header"><h5 class="modal-title">Редактирование заказа {{ o.order_number }}</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+                  <div class="modal-body">
+                    <div class="mb-3"><label class="form-label">Имя клиента</label><input type="text" class="form-control" name="client_name" value="{{ o.client_name }}"></div>
+                    <div class="mb-3"><label class="form-label">Телефон</label><input type="text" class="form-control" name="phone" value="{{ o.phone }}"></div>
+                    <div class="mb-3"><label class="form-label">Адрес</label><input type="text" class="form-control" name="address" value="{{ o.address }}"></div>
+                    <div class="mb-3"><label class="form-label">Заметка</label><textarea class="form-control" name="note">{{ o.note or '' }}</textarea></div>
+                    <div class="mb-3"><label class="form-label">Курьер</label><select class="form-select" name="courier_id"><option value="">Авто</option>{% for c in couriers %}<option value="{{ c.id }}" {% if o.courier_id==c.id %}selected{% endif %}>{{ c.name }}</option>{% endfor %}</select></div>
                   </div>
-                </div>
+                  <div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button><button type="submit" class="btn btn-primary">Сохранить</button></div>
+                </form></div></div>
+              </div>
             </td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div class="tab-pane fade" id="tabZones">
+    {% for zn, lst in orders_by_zone.items() %}
+    <div class="mb-3">
+      <div class="d-flex justify-content-between align-items-center">
+        <h5 class="mb-0">{{ zn }}</h5>
+        <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#zoneTable{{ loop.index }}">Свернуть / Развернуть</button>
+      </div>
+      <div class="collapse show" id="zoneTable{{ loop.index }}">
+        <div class="table-responsive">
+          <table class="table table-striped mt-2">
+            <thead><tr><th>ID</th><th>№</th><th>Клиент</th><th>Телефон</th><th>Адрес</th><th>Статус</th><th>Координаты</th><th>Зона доставки</th><th>Курьер</th><th>Комментарий / Фото</th><th>Действия</th></tr></thead>
+            <tbody>
+              {% for o in lst %}
+              <tr data-id="{{ o.id }}" class="{% if not o.zone %}table-warning{% endif %}">
+                <td>{{ o.id }}</td>
+                <td>{{ o.order_number }}</td>
+                <td>{{ o.client_name }}</td>
+                <td>{{ o.phone }}</td>
+                <td>{{ o.address }}</td>
+                <td>
+                  {% set status_class = {
+                      'Складская обработка':'bg-secondary',
+                      'Подготовлен к доставке':'bg-info',
+                      'Выдан':'bg-warning',
+                      'Доставлен':'bg-success'
+                  } %}
+                  <span class="badge {{ status_class.get(o.status, 'bg-secondary') }}">{{ o.status }}</span>
+                </td>
+                <td class="coords-cell">{% if o.latitude and o.longitude %}✔{% else %}✘{% if not o.zone %} <button class="btn btn-sm btn-outline-primary set-point-btn" data-id="{{ o.id }}">Указать точку</button>{% endif %}{% endif %}</td>
+                <td class="zone-cell">{{ o.zone or 'Не определена' }}</td>
+                <td>{{ o.courier.name if o.courier else '—' }}</td>
+                <td>{% if o.comment %}<div>{{ o.comment }}</div>{% endif %}{% if o.photo_filename %}<a href="{{ url_for('static', filename='uploads/' + o.photo_filename) }}" target="_blank">Фото</a>{% endif %}</td>
+                <td></td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+</div>
+<div class="modal fade" id="setPointModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header"><h5 class="modal-title">Установить координаты</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+      <div class="modal-body"><div id="pointMap" style="height:400px;"></div></div>
+      <div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button><button type="button" class="btn btn-primary" id="savePointBtn">Сохранить</button></div>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/templates/users.html
+++ b/templates/users.html
@@ -1,0 +1,49 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Пользователи</h2>
+<button class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#createUserModal">Создать курьера</button>
+<div class="table-responsive">
+<table class="table table-striped">
+  <thead><tr><th>Username</th><th>Роль</th><th>Зоны</th></tr></thead>
+  <tbody>
+  {% for u in users %}
+  <tr><td>{{ u.user.username }}</td><td>{{ u.user.role }}</td><td>{{ u.zones }}</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+</div>
+<div class="modal fade" id="createUserModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" action="{{ url_for('create_user') }}">
+        <div class="modal-header">
+          <h5 class="modal-title">Создать курьера</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">Имя пользователя</label>
+            <input class="form-control" name="username">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Пароль</label>
+            <input type="password" class="form-control" name="password">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Зоны</label>
+            <select class="form-select" name="zones" multiple>
+              {% for z in zones %}
+              <option value="{{ z.name }}">{{ z.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button>
+          <button type="submit" class="btn btn-primary">Создать</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- replace top nav with sidebar and mobile off-canvas
- highlight orders without zone and allow setting coordinates via modal map
- group orders by zones with collapsible tables
- add simple user management section
- expose API for setting order point
- update styles and scripts for new layout

## Testing
- `python -m py_compile app.py models.py geocode.py`


------
https://chatgpt.com/codex/tasks/task_e_685142cede98832c8b52acaff60b842b