### PR TITLE
Add optional column support and import error display

### DIFF
--- a/templates/import_finish.html
+++ b/templates/import_finish.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Импорт завершён</h1>
+<p>Импортировано заказов: {{ imported }}</p>
+
+{% if errors %}
+  <div class="alert alert-warning" role="alert">
+      <strong>Внимание!</strong> При импорте возникли ошибки:
+      <ul>
+         {% for err in errors %}
+            <li>{{ err }}</li>
+         {% endfor %}
+      </ul>
+  </div>
+{% endif %}
+
+<a class="btn btn-primary" href="{{ url_for('orders') }}">К списку заказов</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement `_normalize_header` helper
- update import_orders_finish to handle optional columns and show errors
- add template to display import summary with errors

## Testing
- `python -m py_compile app.py models.py geocode.py`

------
https://chatgpt.com/codex/tasks/task_e_68515a8d03ac832cb17b0e3f9bcc0883