### PR TITLE
Improve order import error handling

### DIFF
--- a/templates/orders.html
+++ b/templates/orders.html
@@ -4,6 +4,15 @@
 {% if current_user.role == 'admin' %}
 <a class="btn btn-sm btn-success mb-3" href="{{ url_for('import_orders') }}">Импорт заказов</a>
 {% endif %}
+{% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+    <ul class="flashes">
+      {% for category, message in messages %}
+        <li class="{{ category }}">{{ message }}</li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+{% endwith %}
 <ul class="nav nav-tabs mb-3" id="ordersTabs" role="tablist">
   <li class="nav-item" role="presentation"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tabAll" type="button">Все</button></li>
   <li class="nav-item" role="presentation"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabZones" type="button">По зонам</button></li>


### PR DESCRIPTION
## Summary
- warn about skipped optional columns and log row failures on import
- show flash messages in orders list

## Testing
- `python -m py_compile app.py models.py geocode.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_68515ee59d68832c8ac5256f0695fa5d