### PR TITLE
Improve import optional column handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -555,36 +555,37 @@ def import_orders_finish():
 
     header_row = [h.strip() if isinstance(h, str) else '' for h in rows[0]]
 
-    IGNORE_MARKERS = ('(optional)', '(opt)', '[optional]', '[opt]')
-    col_map, skip_cols = {}, set()
-    optional_cols = []
+    optional_pattern = re.compile(r"\(optional\)|\[optional\]|optional", re.I)
+    col_map = {}
+    optional_indices = {}
     for idx, col_name in enumerate(header_row):
         if not col_name:
             continue
-        lowered = col_name.lower()
-        if any(m in lowered for m in IGNORE_MARKERS):
-            skip_cols.add(idx)
-            cleaned = re.sub(r"\s*[\[\(]?\s*optional\s*[\]\)]?", "", col_name, flags=re.I).strip()
-            if cleaned:
-                optional_cols.append(cleaned)
-            continue
-        canonical = _normalize_header(lowered)
+        optional = bool(optional_pattern.search(col_name))
+        cleaned = optional_pattern.sub("", col_name).strip()
+        canonical = _normalize_header(cleaned.lower())
         col_map[idx] = canonical
+        if optional:
+            optional_indices[idx] = canonical
 
     imported = 0
     errors = []
     skipped_rows = []
+    optional_skipped = set()
 
     for row_num, row in enumerate(rows[1:], start=2):
         if all((not c or str(c).strip() == '') for c in row):
             continue
         data = {}
-        for idx, value in enumerate(row):
-            if idx in skip_cols:
+        for idx, field in col_map.items():
+            if idx >= len(row) or row[idx] == '' or row[idx] is None:
+                if idx in optional_indices:
+                    optional_skipped.add(optional_indices[idx])
+                    continue
+                if idx >= len(row):
+                    raise ValueError(f'Отсутствует поле {field}')
                 continue
-            field = col_map.get(idx)
-            if not field:
-                continue
+            value = row[idx]
             data[field] = value.strip() if isinstance(value, str) else value
 
         try:
@@ -603,18 +604,19 @@ def import_orders_finish():
             imported += 1
         except Exception as exc:
             errors.append(f'Строка {row_num}: {exc}')
+            print(f"[!] Ошибка в строке {row_num}: {exc}")
             app.logger.error('Error importing row %s: %s', row_num, exc)
-            skipped_rows.append(row)
+            skipped_rows.append((row_num, str(exc)))
 
     print(f"[+] Импортировано строк: {imported} из {len(rows)}")
 
     db.session.commit()
     print(f"[✓] В базе добавлено заказов: {imported}")
 
-    if optional_cols:
-        flash('⚠ Пропущены необязательные поля: ' + ', '.join(optional_cols), 'warning')
+    if optional_skipped:
+        flash(f"⚠ Пропущены необязательные поля: {', '.join(sorted(optional_skipped))}", "warning")
     if skipped_rows:
-        flash(f'❌ Пропущены {len(skipped_rows)} строки — из-за ошибок в данных. Подробности в логах.', 'warning')
+        flash(f"❌ Пропущены {len(skipped_rows)} строк(и) — из-за ошибок в данных. Подробности в логах.", "danger")
         app.logger.error('Skipped %s rows due to errors', len(skipped_rows))
 
     try:


### PR DESCRIPTION
## Summary
- handle optional columns in `import_orders_finish`
- skip rows individually on import errors

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6851629bb0fc832c9ec942ddc9e3bb7b