### PR TITLE
Limit geocoding to Bishkek region

### DIFF
--- a/geocode.py
+++ b/geocode.py
@@ -18,8 +18,11 @@ def geocode_address(address: str):
         "q": address,
         "format": "json",
         "limit": 1,
+        "countrycodes": "kg",
+        "viewbox": "73.2,43.5,75.4,42.2",
+        "bounded": 1,
     }
-    headers = {"User-Agent": "delivery_crm_app"}
+    headers = {"User-Agent": "delivery_crm_app (bishkek only)"}
     try:
         resp = requests.get(
             "https://nominatim.openstreetmap.org/search",


### PR DESCRIPTION
## Summary
- restrict Nominatim requests to the Chuy region of Kyrgyzstan
- update the user agent string used for geocoding

## Testing
- `python -m py_compile geocode.py`

------
https://chatgpt.com/codex/tasks/task_e_685406526ecc832c9f59b7210c312077