### PR TITLE
Add admin deletion of orders and imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -309,6 +309,29 @@ def add_comment_photo(order_id):
     return redirect(url_for('orders'))
 
 
+@app.route('/orders/<int:order_id>/delete', methods=['POST'])
+@admin_required
+def delete_order(order_id):
+    """Delete a single order."""
+    order = Order.query.get_or_404(order_id)
+    db.session.delete(order)
+    db.session.commit()
+    flash('Заказ удалён', 'success')
+    return redirect(url_for('orders'))
+
+
+@app.route('/orders/delete_batch', methods=['POST'])
+@admin_required
+def delete_batch():
+    """Delete all orders imported in the given batch."""
+    batch = request.form.get('batch')
+    if batch:
+        Order.query.filter_by(import_batch=batch).delete()
+        db.session.commit()
+        flash(f"Импорт '{batch}' удалён", 'success')
+    return redirect(url_for('orders'))
+
+
 @app.route('/map')
 @login_required
 def map_view():

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -21,7 +21,15 @@
   <div class="tab-pane fade show active" id="tabAll">
     {% for batch, lst in orders_by_batch.items() %}
     <details class="mb-3" {% if loop.first %}open{% endif %}>
-      <summary class="h5">Импорт: {{ batch }}</summary>
+      <summary class="h5 d-flex justify-content-between align-items-center">
+        <span>Импорт: {{ batch }}</span>
+        {% if current_user.role == 'admin' %}
+        <form method="post" action="{{ url_for('delete_batch') }}" class="ms-2 d-inline" onsubmit="return confirm('Удалить весь импорт?');">
+          <input type="hidden" name="batch" value="{{ batch }}">
+          <button type="submit" class="btn btn-sm btn-danger">Удалить весь импорт</button>
+        </form>
+        {% endif %}
+      </summary>
       <div class="table-responsive mt-2">
         <table class="table table-striped">
           <thead>
@@ -90,9 +98,14 @@
                       <div class="mb-3"><label class="form-label">Заметка</label><textarea class="form-control" name="note">{{ o.note or '' }}</textarea></div>
                       <div class="mb-3"><label class="form-label">Курьер</label><select class="form-select" name="courier_id"><option value="">Авто</option>{% for c in couriers %}<option value="{{ c.id }}" {% if o.courier_id==c.id %}selected{% endif %}>{{ c.name }}</option>{% endfor %}</select></div>
                     </div>
-                    <div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button><button type="submit" class="btn btn-primary">Сохранить</button></div>
+                <div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button><button type="submit" class="btn btn-primary">Сохранить</button></div>
                   </form></div></div>
                 </div>
+                {% if current_user.role == 'admin' %}
+                <form method="post" action="{{ url_for('delete_order', order_id=o.id) }}" class="d-inline" onsubmit="return confirm('Удалить заказ?');">
+                  <button type="submit" class="btn btn-sm btn-danger mt-1">🗑 Удалить</button>
+                </form>
+                {% endif %}
               </td>
             </tr>
             {% endfor %}
@@ -134,7 +147,13 @@
                 <td class="zone-cell">{{ o.zone or 'Не определена' }}</td>
                 <td>{{ o.courier.name if o.courier else '—' }}</td>
                 <td>{% if o.comment %}<div>{{ o.comment }}</div>{% endif %}{% if o.photo_filename %}<a href="{{ url_for('static', filename='uploads/' + o.photo_filename) }}" target="_blank">Фото</a>{% endif %}</td>
-                <td></td>
+                <td>
+                  {% if current_user.role == 'admin' %}
+                  <form method="post" action="{{ url_for('delete_order', order_id=o.id) }}" class="d-inline" onsubmit="return confirm('Удалить заказ?');">
+                    <button type="submit" class="btn btn-sm btn-danger">🗑 Удалить</button>
+                  </form>
+                  {% endif %}
+                </td>
               </tr>
               {% endfor %}
             </tbody>


### PR DESCRIPTION
## Summary
- allow admins to remove single orders and delete entire import batches
- show delete actions in order tables

## Testing
- `python -m py_compile app.py models.py config.py geocode.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6854080c2974832cb52c99d8875499e5