### PR TITLE
Improve responsive layout for zones map

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2,3 +2,15 @@ body { padding-top: 0; }
 @media (min-width:768px){
   #sidebarMenu + .flex-grow-1 { margin-left: 220px; }
 }
+
+.leaflet-map {
+  width: 100%;
+  height: 100%;
+}
+
+.map-container {
+  margin-top: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  overflow: hidden;
+}

--- a/templates/zones.html
+++ b/templates/zones.html
@@ -22,7 +22,9 @@
     </tbody>
 </table>
 </div>
-<div id="map" style="height:400px;"></div>
+<div class="map-container" style="width: 100%; height: 50vh;">
+    <div id="map" class="leaflet-map"></div>
+</div>
 {% endblock %}
 {% block scripts %}
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />


### PR DESCRIPTION
## Summary
- update zones page to use a responsive map container
- style `.leaflet-map` and `.map-container` for flexible dimensions

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685436583430832ca14adef3a8fdbd00