### PR TITLE
Implement two-step asynchronous import with progress

### DIFF
--- a/templates/import_mapping.html
+++ b/templates/import_mapping.html
@@ -1,25 +1,49 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>Сопоставление столбцов</h2>
-<form method="post" action="{{ url_for('import_orders_finish') }}">
-  <input type="hidden" name="file_id" value="{{ file_id }}">
-  <input type="hidden" name="batch_name" value="{{ batch_name }}">
+<h2>Сопоставление полей</h2>
+<form id="mapForm" method="post" action="{{ url_for('import_finish', job_id=job_id) }}">
   <div class="form-check mb-3">
-    <input class="form-check-input" type="checkbox" id="headerCheck" name="header" {% if header %}checked{% endif %}>
+    <input class="form-check-input" type="checkbox" id="headerCheck" name="header" checked>
     <label class="form-check-label" for="headerCheck">Первая строка содержит заголовки</label>
   </div>
-  {% set fields = [('order_number','Номер заказа'), ('client_name','Имя клиента'), ('phone','Телефон'), ('address','Адрес')] %}
-  {% for field,label in fields %}
-  <div class="mb-3">
-    <label class="form-label">{{ label }}</label>
-    <select class="form-select" name="{{ field }}">
-      <option value="">-- Не использовать --</option>
-      {% for col in columns %}
-      <option value="{{ col.index }}">{{ col.name }}</option>
+  <table class="table table-sm">
+    <thead>
+      <tr>
+        {% for i in range(column_count) %}
+        <th>Колонка {{ i+1 }}</th>
+        {% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in preview %}
+      <tr>
+        {% for cell in row %}
+        <td>{{ cell }}</td>
+        {% endfor %}
+      </tr>
       {% endfor %}
+    </tbody>
+  </table>
+  <h5>Назначение колонок</h5>
+  {% for i in range(column_count) %}
+  <div class="mb-3">
+    <label class="form-label">Колонка {{ i+1 }}</label>
+    <select class="form-select" name="map_{{ i }}">
+      <option value="">-- Не использовать --</option>
+      <option value="order_number">Номер заказа</option>
+      <option value="client_name">Имя клиента</option>
+      <option value="phone">Телефон</option>
+      <option value="address">Адрес</option>
+      <option value="zone">Зона</option>
+      <option value="comment">Комментарий</option>
     </select>
   </div>
   {% endfor %}
-  <button type="submit" class="btn btn-primary">Импортировать</button>
+  <button type="submit" class="btn btn-primary" id="startBtn">Начать импорт</button>
 </form>
+<script>
+  document.getElementById('startBtn').addEventListener('click', function(){
+    window.open('/import/progress/{{ job_id }}', '_blank');
+  });
+</script>
 {% endblock %}

--- a/templates/import_upload.html
+++ b/templates/import_upload.html
@@ -1,21 +1,10 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Импорт заказов</h2>
-<form id="uploadForm" method="post" enctype="multipart/form-data" action="{{ url_for('import_start') }}">
+<form method="post" enctype="multipart/form-data" action="{{ url_for('import_upload') }}">
   <div class="mb-3">
     <input class="form-control" type="file" name="file" accept=".csv,.xlsx">
   </div>
   <button type="submit" class="btn btn-primary">Загрузить</button>
 </form>
-<script>
-document.getElementById('uploadForm').addEventListener('submit', function(e){
-  e.preventDefault();
-  const fd = new FormData(this);
-  fetch(this.action, {method:'POST', body: fd}).then(r=>r.json()).then(d=>{
-    if(d.job_id){
-      window.open(`/import/progress/${d.job_id}`, '_blank');
-    }
-  });
-});
-</script>
 {% endblock %}

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h2>Заказы</h2>
 {% if current_user.role == 'admin' %}
-<a class="btn btn-sm btn-success mb-3" href="{{ url_for('import_orders') }}">Импорт заказов</a>
+<a class="btn btn-sm btn-success mb-3" href="{{ url_for('import_upload') }}">Импорт заказов</a>
 {% endif %}
 {% with messages = get_flashed_messages(with_categories=true) %}
   {% if messages %}


### PR DESCRIPTION
## Summary
- reintroduce mapping step for order import
- run background import via `/import/finish/<job_id>`
- show column mapping preview and open progress window with JS
- link to new import page

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685436b012bc832ca187131e66fef550