### PR TITLE
Fix maps on zones and orders pages

### DIFF
--- a/static/scripts.js
+++ b/static/scripts.js
@@ -1,5 +1,5 @@
 function initMap(orders, zones) {
-  var map = L.map('map').setView([42.8746, 74.6122], 13);
+  const map = L.map('map').setView([42.8746, 74.6122], 13);
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; OpenStreetMap contributors'
@@ -15,6 +15,20 @@ function initMap(orders, zones) {
       var marker = L.marker([o.lat, o.lng]).addTo(map);
       var popup = '<b>Заказ #' + o.id + '</b><br>' + o.address + '<br>Статус: ' + o.status;
       marker.bindPopup(popup);
+    }
+  });
+}
+
+function initZoneMaps(zones) {
+  zones.forEach(function(z){
+    const map = L.map('map-' + z.id).setView([42.8746, 74.6122], 12);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 19,
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+    if (z.polygon && z.polygon.length) {
+      var poly = L.polygon(z.polygon.map(function(p){ return [p[1], p[0]]; }), {color: z.color}).addTo(map);
+      map.fitBounds(poly.getBounds());
     }
   });
 }

--- a/static/style.css
+++ b/static/style.css
@@ -1,6 +1,16 @@
 body { padding-top: 0; }
-@media (min-width:768px){
+
+@media (min-width:768px) {
   #sidebarMenu + .flex-grow-1 { margin-left: 220px; }
 }
- main
+
+.map-container {
+  width: 100%;
+  height: 50vh;
+  margin-top: 1rem;
+}
+
+.leaflet-map {
+  width: 100%;
+  height: 100%;
 }

--- a/templates/map.html
+++ b/templates/map.html
@@ -1,7 +1,9 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Карта заказов</h2>
-<div id="map"></div>
+<div class="map-container">
+  <div id="map" class="leaflet-map"></div>
+</div>
 {% endblock %}
 {% block scripts %}
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
@@ -9,6 +11,8 @@
 <script>
 var orders = {{ orders|tojson }};
 var zones = {{ zones|tojson }};
-initMap(orders, zones);
+window.addEventListener('DOMContentLoaded', function(){
+  initMap(orders, zones);
+});
 </script>
 {% endblock %}

--- a/templates/zones.html
+++ b/templates/zones.html
@@ -22,14 +22,19 @@
     </tbody>
 </table>
 </div>
-<div class="map-container" style="width: 100%; height: 50vh;">
-    <div id="map" class="leaflet-map"></div>
+{% for z in zones %}
+<div class="map-container">
+    <div id="map-{{ z.id }}" class="leaflet-map"></div>
 </div>
+{% endfor %}
 {% endblock %}
 {% block scripts %}
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
 <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
 <script>
-initMap([], {{ zones|tojson }});
+window.addEventListener('DOMContentLoaded', function(){
+  var zones = {{ zones|tojson }};
+  initZoneMaps(zones);
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show a dedicated map for each zone
- make the orders map responsive
- add CSS for map containers
- initialize maps on DOMContentLoaded

## Testing
- `python -m py_compile app.py models.py geocode.py config.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68543f9b5f88832cba6dc36b33a998b6