### PR TITLE
Add sidebar import progress monitor

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -25,6 +25,14 @@
       <span class="d-block mb-2">{{ current_user.username }}</span>
       <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('logout') }}">Выход</a>
     </div>
+    <div id="import-status" style="padding: 10px; border-top: 1px solid #ddd; font-size: 12px;">
+      <div id="import-title" style="margin-bottom: 4px; font-weight: bold;">Импорт: —</div>
+      <div class="progress" style="height: 8px;">
+        <div id="import-bar" class="progress-bar" style="width:0%; height:100%; background:#007bff;"></div>
+      </div>
+      <div id="import-count">—</div>
+      <ul id="import-errors" style="margin-top: 5px; color: red; list-style-type: disc;"></ul>
+    </div>
   </nav>
 
   <div class="offcanvas offcanvas-start" tabindex="-1" id="offcanvasMenu">

--- a/templates/progress.html
+++ b/templates/progress.html
@@ -6,6 +6,9 @@
 <p id="txt">0 / 0</p>
 <script>
 const jid = "{{ job_id }}";
+if (window.opener && window.opener.startImportMonitor) {
+    window.opener.startImportMonitor(jid, "{{ filename }}");
+}
 function poll(){
     fetch(`/import/status/${jid}`).then(r=>r.json()).then(d=>{
         const pct = d.total_rows? d.processed/d.total_rows*100 : 0;


### PR DESCRIPTION
## Summary
- show import progress in sidebar
- monitor import status via scripts.js
- propagate filename to progress page and start monitor
- expose import errors from backend

## Testing
- `python -m py_compile app.py models.py geocode.py`

------
https://chatgpt.com/codex/tasks/task_e_685440987ec8832cbe6ad37e6a9e5bd5