### PR TITLE
Implement manual coordinate editing via map

### DIFF
--- a/app.py
+++ b/app.py
@@ -318,6 +318,27 @@ def set_point():
     return jsonify({'success': True, 'zone': order.zone})
 
 
+@app.route('/api/orders/<int:order_id>/coordinates', methods=['POST'])
+@login_required
+def set_coordinates(order_id):
+    data = request.json or {}
+    lat = data.get('latitude')
+    lng = data.get('longitude')
+    try:
+        lat = float(lat)
+        lng = float(lng)
+    except (TypeError, ValueError):
+        return jsonify({'success': False}), 400
+    order = Order.query.get_or_404(order_id)
+    order.latitude = lat
+    order.longitude = lng
+    order.zone = detect_zone(lat, lng)
+    c = assign_courier_for_zone(order.zone)
+    order.courier = c
+    db.session.commit()
+    return jsonify({'success': True, 'zone': order.zone})
+
+
 @app.route('/orders/<int:order_id>/add_comment_photo', methods=['POST'])
 @login_required
 def add_comment_photo(order_id):

--- a/static/js/orders.js
+++ b/static/js/orders.js
@@ -1,0 +1,50 @@
+function closeMapModal() {
+    const modal = document.getElementById('mapModal');
+    if (modal) {
+        modal.style.display = 'none';
+    }
+}
+
+function openMapModal(orderId) {
+    const modal = document.getElementById('mapModal');
+    if (!modal) return;
+    modal.style.display = 'block';
+    const container = document.getElementById('mapContainer');
+    container.innerHTML = '';
+    const map = L.map('mapContainer').setView([42.87, 74.6], 13);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
+    let marker;
+    map.on('click', function(e) {
+        if (marker) map.removeLayer(marker);
+        marker = L.marker(e.latlng).addTo(map);
+        modal.dataset.lat = e.latlng.lat;
+        modal.dataset.lng = e.latlng.lng;
+    });
+    setTimeout(() => { map.invalidateSize(); }, 0);
+
+    document.getElementById('saveCoordsBtn').onclick = () => {
+        if (!modal.dataset.lat || !modal.dataset.lng) return;
+        fetch(`/api/orders/${orderId}/coordinates`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                latitude: modal.dataset.lat,
+                longitude: modal.dataset.lng
+            })
+        })
+        .then(res => res.json())
+        .then(data => {
+            if (data && data.success) {
+                const row = document.querySelector(`tr[data-id="${orderId}"]`);
+                if (row) {
+                    row.classList.remove('table-warning');
+                    const ccell = row.querySelector('.coords-cell');
+                    if (ccell) ccell.textContent = '✔';
+                    const zcell = row.querySelector('.zone-cell');
+                    if (zcell && 'zone' in data) zcell.textContent = data.zone || 'Не определена';
+                }
+            }
+            closeMapModal();
+        });
+    };
+}

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -65,7 +65,7 @@
                 </div>
               </td>
               <td class="coords-cell">
-                {% if o.latitude and o.longitude %}✔{% else %}✘{% if not o.zone %} <button class="btn btn-sm btn-outline-primary set-point-btn" data-id="{{ o.id }}">Указать точку</button>{% else %} <a href="{{ url_for('set_coords', order_id=o.id) }}" class="btn btn-sm btn-outline-primary ms-2">Установить на карте</a>{% endif %}{% endif %}
+                {% if o.latitude and o.longitude %}✔{% else %}✘{% if not o.zone %} <button class="btn btn-sm btn-outline-primary" onclick="openMapModal({{ o.id }})">Указать точку</button>{% else %} <a href="{{ url_for('set_coords', order_id=o.id) }}" class="btn btn-sm btn-outline-primary ms-2">Установить на карте</a>{% endif %}{% endif %}
               </td>
               <td class="zone-cell">{{ o.zone or 'Не определена' }}</td>
               <td>{{ o.courier.name if o.courier else '—' }}</td>
@@ -143,7 +143,7 @@
                   } %}
                   <span class="badge {{ status_class.get(o.status, 'bg-secondary') }}">{{ o.status }}</span>
                 </td>
-                <td class="coords-cell">{% if o.latitude and o.longitude %}✔{% else %}✘{% if not o.zone %} <button class="btn btn-sm btn-outline-primary set-point-btn" data-id="{{ o.id }}">Указать точку</button>{% endif %}{% endif %}</td>
+                <td class="coords-cell">{% if o.latitude and o.longitude %}✔{% else %}✘{% if not o.zone %} <button class="btn btn-sm btn-outline-primary" onclick="openMapModal({{ o.id }})">Указать точку</button>{% endif %}{% endif %}</td>
                 <td class="zone-cell">{{ o.zone or 'Не определена' }}</td>
                 <td>{{ o.courier.name if o.courier else '—' }}</td>
                 <td>{% if o.comment %}<div>{{ o.comment }}</div>{% endif %}{% if o.photo_filename %}<a href="{{ url_for('static', filename='uploads/' + o.photo_filename) }}" target="_blank">Фото</a>{% endif %}</td>
@@ -173,4 +173,18 @@
     </div>
   </div>
 </div>
+<div id="mapModal" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.5); z-index:1050;">
+  <div style="background:#fff; margin:50px auto; max-width:600px; padding:10px;">
+    <div id="mapContainer" style="height:400px;"></div>
+    <div class="mt-2 text-end">
+      <button id="saveCoordsBtn" class="btn btn-primary">Сохранить</button>
+      <button class="btn btn-secondary" onclick="closeMapModal()">Отмена</button>
+    </div>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
+<script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
+<script src="{{ url_for('static', filename='js/orders.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add API endpoint for updating order coordinates
- enable "Указать точку" buttons to open map modal
- provide new Leaflet-based map modal and scripts

## Testing
- `python -m py_compile app.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_68548f9f41d0832caa96733eb2a17796