### PR TITLE
Ensure Eventlet usage and CLI-only server start

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,12 @@
 import eventlet
 eventlet.monkey_patch()
 
+import os
+if os.environ.get("FLASK_RUN_FROM_CLI"):
+    raise RuntimeError("❌ Не запускай через 'flask run'. Используй только 'python app.py'.")
+
 import csv
 import json
-import os
 import re
 import threading
 import time


### PR DESCRIPTION
## Summary
- patch Eventlet before other imports and add a guard against `flask run`
- keep the existing `socketio.run` call for the main entrypoint

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685495f5efb4832ca3dcd9cee2457a8a