### PR TITLE
Fix ImportJob ID type

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,14 @@ python app.py
 ```
 
 On first start demo data will be generated automatically. Configuration values can be changed in `config.py` or via environment variables.
-\nThe application uses OpenStreetMap Nominatim for geocoding. Requests are limited to one per second.
+
+If you are upgrading from previous versions remove the old SQLite database so that the new
+`ImportJob` id format is applied:
+
+```bash
+rm Dilivery/database.db
+# or in Windows PowerShell
+del Dilivery\database.db
+```
+
+The application uses OpenStreetMap Nominatim for geocoding. Requests are limited to one per second.

--- a/models.py
+++ b/models.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from flask_login import UserMixin
 from flask_sqlalchemy import SQLAlchemy
-from sqlalchemy.dialects.postgresql import UUID
+
 
 db = SQLAlchemy()
 
@@ -55,7 +55,7 @@ class User(db.Model, UserMixin):
 class ImportJob(db.Model):
     __tablename__ = "import_jobs"
 
-    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid4()))
     filename = db.Column(db.String(256))
     total_rows = db.Column(db.Integer)
     processed_rows = db.Column(db.Integer, default=0)


### PR DESCRIPTION
## Summary
- store ImportJob IDs as strings instead of binary UUID
- explain how to remove the old DB when upgrading

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685568d375f4832ca7aad1a7cf988a17