### PR TITLE
Fix import job UUID and delete_table check

### DIFF
--- a/migrations/versions/8922a5ebcd01_add_processed_rows.py
+++ b/migrations/versions/8922a5ebcd01_add_processed_rows.py
@@ -23,6 +23,7 @@ def upgrade():
                existing_type=sa.NUMERIC(),
                type_=sa.UUID(),
                existing_nullable=False)
+        batch_op.add_column(sa.Column('processed_rows', sa.Integer(), server_default='0'))
 
     # ### end Alembic commands ###
 
@@ -34,5 +35,6 @@ def downgrade():
                existing_type=sa.UUID(),
                type_=sa.NUMERIC(),
                existing_nullable=False)
+        batch_op.drop_column('processed_rows')
 
     # ### end Alembic commands ###

--- a/models.py
+++ b/models.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 from flask_login import UserMixin
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.dialects.postgresql import UUID
 
 
 db = SQLAlchemy()
@@ -55,7 +56,7 @@ class User(db.Model, UserMixin):
 class ImportJob(db.Model):
     __tablename__ = "import_jobs"
 
-    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid4()))
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     filename = db.Column(db.String(256))
     total_rows = db.Column(db.Integer)
     processed_rows = db.Column(db.Integer, default=0)


### PR DESCRIPTION
## Summary
- store ImportJob IDs using UUID type
- validate batch parameter when deleting tables
- adjust initial migration
- update import routes to convert job_id to UUID objects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68556d6085f4832c97e5ef7663beb72e