### PR TITLE
Display zones on a single map

### DIFF
--- a/static/scripts.js
+++ b/static/scripts.js
@@ -19,18 +19,25 @@ function initMap(orders, zones) {
   });
 }
 
-function initZoneMaps(zones) {
-  zones.forEach(function(z){
-    const map = L.map('map-' + z.id).setView([42.8746, 74.6122], 12);
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      maxZoom: 19,
-      attribution: '&copy; OpenStreetMap contributors'
-    }).addTo(map);
+function initZonesMap(zones) {
+  const map = L.map('zones-map').setView([42.8746, 74.6122], 12);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '&copy; OpenStreetMap contributors'
+  }).addTo(map);
+
+  var group = L.featureGroup().addTo(map);
+  zones.forEach(function(z) {
     if (z.polygon && z.polygon.length) {
-      var poly = L.polygon(z.polygon.map(function(p){ return [p[1], p[0]]; }), {color: z.color}).addTo(map);
-      map.fitBounds(poly.getBounds());
+      var poly = L.polygon(z.polygon.map(function(p){ return [p[1], p[0]]; }), {color: z.color});
+      poly.bindPopup(z.name);
+      group.addLayer(poly);
     }
   });
+
+  if (group.getLayers().length) {
+    map.fitBounds(group.getBounds());
+  }
 }
 document.addEventListener('DOMContentLoaded', function(){
   var modalEl = document.getElementById('setPointModal');

--- a/templates/zones.html
+++ b/templates/zones.html
@@ -22,11 +22,9 @@
     </tbody>
 </table>
 </div>
-{% for z in zones %}
 <div class="map-container">
-    <div id="map-{{ z.id }}" class="leaflet-map"></div>
+    <div id="zones-map" class="leaflet-map"></div>
 </div>
-{% endfor %}
 {% endblock %}
 {% block scripts %}
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
@@ -34,7 +32,7 @@
 <script>
 window.addEventListener('DOMContentLoaded', function(){
   var zones = {{ zones|tojson }};
-  initZoneMaps(zones);
+  initZonesMap(zones);
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- streamline zones page to use one map
- show all delivery zones on the new map with popups

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685572842e10832c837d96314e456c80