### PR TITLE
Fix coordinate saving and cleanup warnings

### DIFF
--- a/static/js/orders.js
+++ b/static/js/orders.js
@@ -24,7 +24,7 @@ function openMapModal(orderId) {
 
     document.getElementById('saveCoordsBtn').onclick = () => {
         if (!modal.dataset.lat || !modal.dataset.lng) return;
-        fetch(`/api/orders/${orderId}/coordinates`, {
+        fetch(`/orders/set_coordinates/${orderId}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({

--- a/templates/base.html
+++ b/templates/base.html
@@ -99,7 +99,7 @@
 </div>
 {% endif %}
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
-<script src="/socket.io/socket.io.js"></script>
+<script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
 <script src="{{ url_for('static', filename='scripts.js') }}"></script>
 <script src="{{ url_for('static', filename='js/import_progress.js') }}"></script>
 {% block scripts %}{% endblock %}


### PR DESCRIPTION
## Summary
- add API endpoint for setting order coordinates and alias route
- ensure demo order creation adds objects to session before linking courier
- prevent delete table error when the database table is missing
- update JS to POST coordinates to the new endpoint
- upgrade socket.io client script URL

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685572bda850832cb7b830e074c7161b