### PR TITLE
Add coordinate editing in order modal

### DIFF
--- a/app.py
+++ b/app.py
@@ -289,7 +289,19 @@ def update_order(order_id):
     order.phone = request.form.get("phone", order.phone)
     order.address = request.form.get("address", order.address)
     order.note = request.form.get("note", order.note)
-    if order.address != old_address:
+    lat_val = request.form.get("latitude")
+    lon_val = request.form.get("longitude")
+    manual_coords = False
+    if lat_val and lon_val:
+        try:
+            lat = float(lat_val)
+            lon = float(lon_val)
+            order.latitude = lat
+            order.longitude = lon
+            manual_coords = True
+        except ValueError:
+            flash("Некорректные координаты", "warning")
+    if order.address != old_address and not manual_coords:
         lat, lng = geocode_address(order.address)
         order.latitude = lat
         order.longitude = lng
@@ -298,6 +310,8 @@ def update_order(order_id):
         else:
             order.zone = None
             flash("Не удалось определить координаты по адресу", "warning")
+    if manual_coords and order.latitude and order.longitude:
+        order.zone = detect_zone(order.latitude, order.longitude)
     courier_val = request.form.get("courier_id")
     if courier_val:
         try:

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -35,9 +35,12 @@ function initZoneMaps(zones) {
 document.addEventListener('DOMContentLoaded', function(){
   var modalEl = document.getElementById('setPointModal');
   if(!modalEl) return;
-  var map, marker, currentOrder;
+  var map, marker, currentOrder, latInputId, lonInputId;
   modalEl.addEventListener('shown.bs.modal', function(e){
-    currentOrder = e.relatedTarget.getAttribute('data-id');
+    var trg = e.relatedTarget;
+    currentOrder = trg.getAttribute('data-id');
+    latInputId = trg.getAttribute('data-input-lat');
+    lonInputId = trg.getAttribute('data-input-lon');
     var mapDiv = document.getElementById('pointMap');
     mapDiv.innerHTML = '';
     map = L.map('pointMap').setView([42.8746,74.6122],13);
@@ -55,21 +58,27 @@ document.addEventListener('DOMContentLoaded', function(){
   document.getElementById('savePointBtn').addEventListener('click', function(){
     if(!marker) return;
     var latlng = marker.getLatLng();
-    fetch('/orders/set_point', {
-      method:'POST',
-      headers:{'Content-Type':'application/x-www-form-urlencoded'},
-      body:new URLSearchParams({order_id: currentOrder, lat: latlng.lat, lon: latlng.lng})
-    }).then(r=>r.json()).then(function(data){
-      if(data.success){
-        var row = document.querySelector('tr[data-id="'+currentOrder+'"]');
-        if(row){
-          row.classList.remove('table-warning');
-          row.querySelector('.zone-cell').textContent = data.zone || 'Не определена';
-          row.querySelector('.coords-cell').textContent = '✔';
+    if(latInputId && lonInputId){
+      document.getElementById(latInputId).value = latlng.lat;
+      document.getElementById(lonInputId).value = latlng.lng;
+      bootstrap.Modal.getInstance(modalEl).hide();
+    }else{
+      fetch('/orders/set_point', {
+        method:'POST',
+        headers:{'Content-Type':'application/x-www-form-urlencoded'},
+        body:new URLSearchParams({order_id: currentOrder, lat: latlng.lat, lon: latlng.lng})
+      }).then(r=>r.json()).then(function(data){
+        if(data.success){
+          var row = document.querySelector('tr[data-id="'+currentOrder+'"]');
+          if(row){
+            row.classList.remove('table-warning');
+            row.querySelector('.zone-cell').textContent = data.zone || 'Не определена';
+            row.querySelector('.coords-cell').textContent = '✔';
+          }
+          bootstrap.Modal.getInstance(modalEl).hide();
         }
-        bootstrap.Modal.getInstance(modalEl).hide();
-      }
-    });
+      });
+    }
   });
 });
 

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -97,6 +97,9 @@
                       <div class="mb-3"><label class="form-label">Адрес</label><input type="text" class="form-control" name="address" value="{{ o.address }}"></div>
                       <div class="mb-3"><label class="form-label">Заметка</label><textarea class="form-control" name="note">{{ o.note or '' }}</textarea></div>
                       <div class="mb-3"><label class="form-label">Курьер</label><select class="form-select" name="courier_id"><option value="">Авто</option>{% for c in couriers %}<option value="{{ c.id }}" {% if o.courier_id==c.id %}selected{% endif %}>{{ c.name }}</option>{% endfor %}</select></div>
+                      <input type="hidden" name="latitude" id="lat-{{ o.id }}" value="{{ o.latitude or '' }}">
+                      <input type="hidden" name="longitude" id="lon-{{ o.id }}" value="{{ o.longitude or '' }}">
+                      <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#setPointModal" data-input-lat="lat-{{ o.id }}" data-input-lon="lon-{{ o.id }}">{% if o.latitude and o.longitude %}Изменить точку{% else %}Указать точку{% endif %}</button>
                     </div>
                 <div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button><button type="submit" class="btn btn-primary">Сохранить</button></div>
                   </form></div></div>


### PR DESCRIPTION
## Summary
- allow setting coordinates when editing orders
- update map modal script to support forms
- assign zone from manual coordinates in backend

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855736bd65c832c8f12896a4e3640c1