### PR TITLE
Fix progress bar and map reinit bugs

### DIFF
--- a/static/js/import_progress.js
+++ b/static/js/import_progress.js
@@ -7,7 +7,10 @@ document.addEventListener('DOMContentLoaded', function () {
   const socket = io();
 
   function update(data) {
-    if (!data) return;
+    if (!data) {
+      toast.hide();
+      return;
+    }
     const pct = data.total ? (data.processed / data.total) * 100 : 0;
     bar.style.width = pct + '%';
     txt.textContent = `${data.processed}/${data.total}`;

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -49,6 +49,10 @@ document.addEventListener('DOMContentLoaded', function(){
     latInputId = trg.getAttribute('data-input-lat');
     lonInputId = trg.getAttribute('data-input-lon');
     var mapDiv = document.getElementById('pointMap');
+    if (map) {
+      map.off();
+      map.remove();
+    }
     mapDiv.innerHTML = '';
     map = L.map('pointMap').setView([42.8746,74.6122],13);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {


### PR DESCRIPTION
## Summary
- ensure toast hides when no import job is active
- destroy map instance before reinitialization in modal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68557ca03444832c8364572e63400172