### PR TITLE
Implement persistent import progress toast hide

### DIFF
--- a/static/js/import_progress.js
+++ b/static/js/import_progress.js
@@ -4,7 +4,14 @@ document.addEventListener('DOMContentLoaded', function () {
   const toast = new bootstrap.Toast(toastEl, { autohide: false });
   const bar = document.getElementById('import-progress-bar');
   const txt = document.getElementById('import-progress-text');
+  const closeBtn = toastEl.querySelector('.btn-close');
   const socket = io();
+
+  if (closeBtn) {
+    closeBtn.addEventListener('click', () => {
+      sessionStorage.setItem('import_hidden', 'true');
+    });
+  }
 
   function update(data) {
     if (!data) return;
@@ -12,7 +19,9 @@ document.addEventListener('DOMContentLoaded', function () {
     bar.style.width = pct + '%';
     txt.textContent = `${data.processed}/${data.total}`;
     if (data.status === 'running') {
-      toast.show();
+      if (!sessionStorage.getItem('import_hidden')) {
+        toast.show();
+      }
     } else {
       setTimeout(() => toast.hide(), 2000);
     }

--- a/templates/import_mapping.html
+++ b/templates/import_mapping.html
@@ -43,6 +43,7 @@
 </form>
 <script>
   document.getElementById('startBtn').addEventListener('click', function(){
+    sessionStorage.removeItem('import_hidden');
     window.open('/import/progress/{{ job_id }}', '_blank');
   });
 </script>

--- a/templates/import_upload.html
+++ b/templates/import_upload.html
@@ -1,10 +1,15 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Импорт заказов</h2>
-<form method="post" enctype="multipart/form-data" action="{{ url_for('import_upload') }}">
+<form id="uploadForm" method="post" enctype="multipart/form-data" action="{{ url_for('import_upload') }}">
   <div class="mb-3">
     <input class="form-control" type="file" name="file" accept=".csv,.xlsx">
   </div>
   <button type="submit" class="btn btn-primary">Загрузить</button>
 </form>
+<script>
+  document.getElementById('uploadForm').addEventListener('submit', function(){
+    sessionStorage.removeItem('import_hidden');
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- persist toast hidden state in sessionStorage
- show progress toast only if not hidden
- clear hidden flag when starting a new import

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68558068b03c832c851aae010c7e5db3