### PR TITLE
Implement courier dashboard and endpoints

### DIFF
--- a/static/js/courier.js
+++ b/static/js/courier.js
@@ -1,0 +1,85 @@
+window.addEventListener('DOMContentLoaded', function(){
+  const takeBtn = document.getElementById('takeBtn');
+  const ordersBody = document.getElementById('ordersBody');
+  const counterEl = document.getElementById('counterText');
+
+  function updateCounter(){
+    const count = document.querySelectorAll('.order-check').length;
+    if(counterEl) counterEl.textContent = count;
+  }
+
+  function updateMarker(id, status){
+    const m = window.courierMarkers[id];
+    if(!m) return;
+    if(status === 'out_for_delivery'){
+      m.setStyle({color:'orange', fillColor:'orange'});
+    }else if(status === 'delivered'){
+      m.remove();
+      delete window.courierMarkers[id];
+      return;
+    }
+    const popup = `<b>Заказ #${id}</b><br>${m.options.address}<br>${status}`;
+    m.bindPopup(popup);
+  }
+
+  takeBtn && takeBtn.addEventListener('click', function(){
+    const ids = Array.from(document.querySelectorAll('.order-check:checked')).map(cb => cb.closest('tr').dataset.id);
+    if(!ids.length) return;
+    fetch('/courier/take', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ids: ids})
+    }).then(r=>r.json()).then(data=>{
+      if(data.success){
+        ids.forEach(function(id){
+          const row = document.querySelector(`tr[data-id="${id}"]`);
+          if(row){
+            row.querySelector('.order-check').remove();
+            row.querySelector('.status-cell').textContent = 'out_for_delivery';
+            const actions = row.querySelector('.actions');
+            const btn = document.createElement('button');
+            btn.className = 'btn btn-sm btn-success deliver-btn';
+            btn.textContent = 'Доставлен';
+            btn.addEventListener('click', deliverHandler);
+            actions.appendChild(btn);
+          }
+          updateMarker(id, 'out_for_delivery');
+        });
+        updateCounter();
+      }
+    });
+  });
+
+  function deliverHandler(ev){
+    const row = ev.target.closest('tr');
+    const id = row.dataset.id;
+    fetch(`/courier/delivered/${id}`, {method:'POST'}).then(r=>r.json()).then(data=>{
+      if(data.success){
+        row.remove();
+        updateMarker(id, 'delivered');
+        updateCounter();
+      }
+    });
+  }
+
+  document.querySelectorAll('.deliver-btn').forEach(btn => btn.addEventListener('click', deliverHandler));
+
+  // map init
+  const mapEl = document.getElementById('courierMap');
+  if(mapEl){
+    const map = L.map('courierMap').setView([42.8746,74.6122], 12);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom:19}).addTo(map);
+    window.courierMarkers = {};
+    courierOrders.forEach(function(o){
+      if(o.lat && o.lng){
+        const color = o.status === 'prepared' ? 'blue' : (o.status === 'out_for_delivery' ? 'orange' : 'green');
+        const m = L.circleMarker([o.lat, o.lng], {radius:8, color:color, fillColor:color, fillOpacity:1}).addTo(map);
+        m.options.address = o.address;
+        m.bindPopup(`<b>Заказ #${o.order_number}</b><br>${o.address}<br>${o.status}`);
+        window.courierMarkers[o.id] = m;
+      }
+    });
+  }
+
+  updateCounter();
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,10 +11,14 @@
 {% if current_user.is_authenticated %}
 <div class="d-flex">
   <nav id="sidebarMenu" class="d-none d-md-flex flex-column flex-shrink-0 p-3 bg-light position-fixed" style="width:220px;height:100vh;">
-    <a class="fs-4 text-decoration-none mb-3" href="{{ url_for('orders') }}">CRM</a>
+    <a class="fs-4 text-decoration-none mb-3" href="{{ url_for(current_user.role == 'courier' and 'courier_dashboard' or 'orders') }}">CRM</a>
     <ul class="nav nav-pills flex-column mb-auto">
+      {% if current_user.role == 'courier' %}
+      <li class="nav-item"><a class="nav-link" href="{{ url_for('courier_dashboard') }}">Мои заказы</a></li>
+      {% else %}
       <li class="nav-item"><a class="nav-link" href="{{ url_for('orders') }}">Заказы</a></li>
       <li><a class="nav-link" href="{{ url_for('map_view') }}">Карта заказов</a></li>
+      {% endif %}
       {% if current_user.role == 'admin' %}
       <li><a class="nav-link" href="{{ url_for('zones') }}">Зоны доставки</a></li>
       <li><a class="nav-link" href="{{ url_for('users') }}">Пользователи</a></li>
@@ -48,8 +52,12 @@
     </div>
     <div class="offcanvas-body">
       <ul class="nav nav-pills flex-column mb-auto">
+        {% if current_user.role == 'courier' %}
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('courier_dashboard') }}">Мои заказы</a></li>
+        {% else %}
         <li class="nav-item"><a class="nav-link" href="{{ url_for('orders') }}">Заказы</a></li>
         <li><a class="nav-link" href="{{ url_for('map_view') }}">Карта заказов</a></li>
+        {% endif %}
         {% if current_user.role == 'admin' %}
         <li><a class="nav-link" href="{{ url_for('zones') }}">Зоны доставки</a></li>
         <li><a class="nav-link" href="{{ url_for('users') }}">Пользователи</a></li>

--- a/templates/courier.html
+++ b/templates/courier.html
@@ -1,0 +1,53 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Кабинет курьера</h2>
+<ul class="nav nav-tabs" id="courierTabs" role="tablist">
+  <li class="nav-item" role="presentation">
+    <button class="nav-link active" id="orders-tab" data-bs-toggle="tab" data-bs-target="#tabOrders" type="button" role="tab">Заказы</button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="map-tab" data-bs-toggle="tab" data-bs-target="#tabMap" type="button" role="tab">Карта</button>
+  </li>
+</ul>
+<div class="tab-content pt-3">
+  <div class="tab-pane fade show active" id="tabOrders" role="tabpanel">
+    <h5 class="mb-3">Заказов к выдаче: <span id="counterText">{{ prepared_count }}</span></h5>
+    <div class="table-responsive">
+      <table class="table table-striped">
+        <thead><tr><th></th><th>№</th><th>Адрес</th><th class="text-center">Статус</th><th class="text-center">Действия</th></tr></thead>
+        <tbody id="ordersBody">
+        {% for o in orders %}
+          <tr data-id="{{ o.id }}">
+            <td>
+              {% if o.status == 'prepared' %}
+              <input type="checkbox" class="form-check-input order-check">
+              {% endif %}
+            </td>
+            <td>{{ o.order_number }}</td>
+            <td>{{ o.address }}</td>
+            <td class="status-cell">{{ o.status }}</td>
+            <td class="actions">
+              {% if o.status == 'out_for_delivery' %}
+              <button class="btn btn-sm btn-success deliver-btn">Доставлен</button>
+              {% endif %}
+            </td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <button id="takeBtn" class="btn btn-primary mt-2">Взять в работу</button>
+  </div>
+  <div class="tab-pane fade" id="tabMap" role="tabpanel">
+    <div id="courierMap" style="width:100%;height:400px;"></div>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
+<script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
+<script>
+  const courierOrders = {{ all_orders|tojson }};
+</script>
+<script src="{{ url_for('static', filename='js/courier.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add courier dashboard page
- handle courier-specific routing in `app.py`
- update navigation to point couriers at the new dashboard
- implement dashboard UI and JS helpers

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68559ce54e04832c9eaf69b6deaf24f7