### PR TITLE
Fix courier order visibility and map

### DIFF
--- a/templates/courier.html
+++ b/templates/courier.html
@@ -17,17 +17,17 @@
         <thead><tr><th></th><th>№</th><th>Адрес</th><th class="text-center">Статус</th><th class="text-center">Действия</th></tr></thead>
         <tbody id="ordersBody">
         {% for o in orders %}
-          <tr data-id="{{ o.id }}">
+          <tr data-id="{{ o.id }}" data-status="{{ o.status }}">
             <td>
-              {% if o.status == 'prepared' %}
-              <input type="checkbox" class="form-check-input order-check">
+              {% if o.status == 'Подготовлен к доставке' %}
+              <button class="btn btn-sm btn-primary take-btn">Принять в работу</button>
               {% endif %}
             </td>
             <td>{{ o.order_number }}</td>
             <td>{{ o.address }}</td>
             <td class="status-cell">{{ o.status }}</td>
             <td class="actions">
-              {% if o.status == 'out_for_delivery' %}
+              {% if o.status == 'Выдано на доставку' %}
               <button class="btn btn-sm btn-success deliver-btn">Доставлен</button>
               {% endif %}
             </td>
@@ -36,7 +36,6 @@
         </tbody>
       </table>
     </div>
-    <button id="takeBtn" class="btn btn-primary mt-2">Взять в работу</button>
   </div>
   <div class="tab-pane fade" id="tabMap" role="tabpanel">
     <div id="courierMap" style="width:100%;height:400px;"></div>

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -53,7 +53,7 @@
                 {% set status_class = {
                     'Складская обработка':'bg-secondary',
                     'Подготовлен к доставке':'bg-info',
-                    'Выдан':'bg-warning',
+                    'Выдано на доставку':'bg-warning',
                     'Доставлен':'bg-success'
                 } %}
                 <span class="badge {{ status_class.get(o.status, 'bg-secondary') }}">{{ o.status }}</span>
@@ -62,7 +62,7 @@
                   <form method="post" class="d-flex">
                     <input type="hidden" name="id" value="{{ o.id }}">
                     <select name="status" class="form-select form-select-sm me-2">
-                      {% for st in ['Складская обработка','Подготовлен к доставке','Выдан','Доставлен'] %}
+                      {% for st in ['Складская обработка','Подготовлен к доставке','Выдано на доставку','Доставлен'] %}
                       <option value="{{ st }}" {% if o.status==st %}selected{% endif %}>{{ st }}</option>
                       {% endfor %}
                     </select>
@@ -147,7 +147,7 @@
                   {% set status_class = {
                       'Складская обработка':'bg-secondary',
                       'Подготовлен к доставке':'bg-info',
-                      'Выдан':'bg-warning',
+                      'Выдано на доставку':'bg-warning',
                       'Доставлен':'bg-success'
                   } %}
                   <span class="badge {{ status_class.get(o.status, 'bg-secondary') }}">{{ o.status }}</span>


### PR DESCRIPTION
## Summary
- show courier orders with Russian statuses
- handle taking orders one-by-one
- display correct status options for admin
- initialize courier map lazily and keep markers in sync

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a0675f44832ca5076979a9fd1224