### PR TITLE
Add delivery zones overlay for manual point selection

### DIFF
--- a/static/js/orders.js
+++ b/static/js/orders.js
@@ -35,6 +35,19 @@ function openMapModal(orderId) {
     container.innerHTML = '';
     window.orderMap = L.map('mapContainer').setView([42.87, 74.6], 13);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(window.orderMap);
+    const group = L.featureGroup().addTo(window.orderMap);
+    if (window.zonesData) {
+        window.zonesData.forEach(z => {
+            if (z.polygon && z.polygon.length) {
+                const poly = L.polygon(z.polygon.map(p => [p[1], p[0]]), {color: z.color});
+                poly.bindPopup(z.name);
+                group.addLayer(poly);
+            }
+        });
+        if (group.getLayers().length) {
+            window.orderMap.fitBounds(group.getBounds());
+        }
+    }
     let marker;
     window.orderMap.on('click', function(e) {
         if (marker) window.orderMap.removeLayer(marker);
@@ -98,6 +111,8 @@ function openMapModal(orderId) {
                     if (ccell) ccell.textContent = '✔';
                     const zcell = row.querySelector('.zone-cell');
                     if (zcell && 'zone' in data) zcell.textContent = data.zone || 'Не определена';
+                    const courierCell = row.querySelector('.courier-cell');
+                    if (courierCell && 'courier' in data) courierCell.textContent = data.courier || '—';
                 }
             }
             closeMapModal();

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -69,6 +69,19 @@ document.addEventListener('DOMContentLoaded', function(){
       maxZoom:19,
       attribution:'&copy; OpenStreetMap contributors'
     }).addTo(map);
+    var group = L.featureGroup().addTo(map);
+    if(window.zonesData){
+      window.zonesData.forEach(function(z){
+        if(z.polygon && z.polygon.length){
+          var poly = L.polygon(z.polygon.map(function(p){return [p[1], p[0]];}), {color:z.color});
+          poly.bindPopup(z.name);
+          group.addLayer(poly);
+        }
+      });
+      if(group.getLayers().length){
+        map.fitBounds(group.getBounds());
+      }
+    }
     marker = null;
     if(zoom === 16){
       marker = L.marker([startLat,startLon], {draggable: true}).addTo(map);
@@ -122,6 +135,8 @@ document.addEventListener('DOMContentLoaded', function(){
             row.classList.remove('table-warning');
             row.querySelector('.zone-cell').textContent = data.zone || 'Не определена';
             row.querySelector('.coords-cell').textContent = '✔';
+            var ccell = row.querySelector('.courier-cell');
+            if(ccell) ccell.textContent = data.courier || '—';
           }
           bootstrap.Modal.getInstance(modalEl).hide();
         }

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -74,7 +74,7 @@
                 {% if o.latitude and o.longitude %}✔{% else %}✘{% if not o.zone %} <button class="btn btn-sm btn-outline-primary" onclick="openMapModal({{ o.id }})">Указать точку</button>{% else %} <a href="{{ url_for('set_coords', order_id=o.id) }}" class="btn btn-sm btn-outline-primary ms-2">Установить на карте</a>{% endif %}{% endif %}
               </td>
               <td class="zone-cell">{{ o.zone or 'Не определена' }}</td>
-              <td>{{ o.courier.name if o.courier else '—' }}</td>
+              <td class="courier-cell">{{ o.courier.name if o.courier else '—' }}</td>
               <td>
                 {% if o.comment %}<div>{{ o.comment }}</div>{% endif %}
                 {% if o.photo_filename %}<a href="{{ url_for('static', filename='uploads/' + o.photo_filename) }}" target="_blank">Фото</a>{% endif %}
@@ -154,7 +154,7 @@
                 </td>
                 <td class="coords-cell">{% if o.latitude and o.longitude %}✔{% else %}✘{% if not o.zone %} <button class="btn btn-sm btn-outline-primary" onclick="openMapModal({{ o.id }})">Указать точку</button>{% endif %}{% endif %}</td>
                 <td class="zone-cell">{{ o.zone or 'Не определена' }}</td>
-                <td>{{ o.courier.name if o.courier else '—' }}</td>
+                <td class="courier-cell">{{ o.courier.name if o.courier else '—' }}</td>
                 <td>{% if o.comment %}<div>{{ o.comment }}</div>{% endif %}{% if o.photo_filename %}<a href="{{ url_for('static', filename='uploads/' + o.photo_filename) }}" target="_blank">Фото</a>{% endif %}</td>
                 <td>
                   {% if current_user.role == 'admin' %}
@@ -200,4 +200,7 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
 <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
 <script src="{{ url_for('static', filename='js/orders.js') }}"></script>
+<script>
+  window.zonesData = {{ zones|tojson }};
+</script>
 {% endblock %}

--- a/templates/set_coords.html
+++ b/templates/set_coords.html
@@ -14,11 +14,24 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
 <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
 <script>
+var zones = {{ zones|tojson }};
+window.zonesData = zones;
 var map = L.map('map').setView([42.8746, 74.6122], 13);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; OpenStreetMap contributors'
 }).addTo(map);
+var group = L.featureGroup().addTo(map);
+zones.forEach(function(z){
+    if(z.polygon && z.polygon.length){
+        var poly = L.polygon(z.polygon.map(function(p){return [p[1], p[0]];}), {color:z.color});
+        poly.bindPopup(z.name);
+        group.addLayer(poly);
+    }
+});
+if(group.getLayers().length){
+    map.fitBounds(group.getBounds());
+}
 var marker = null;
 function updateMarker(latlng) {
     if (marker) {


### PR DESCRIPTION
## Summary
- load polygon data on orders and set coords pages
- show zones overlay when picking coordinates
- auto-update courier and zone after marker save

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855aadb4e74832c8bc92ab812678eed