### PR TITLE
Add bulk courier order handling and delivered tab

### DIFF
--- a/static/js/courier.js
+++ b/static/js/courier.js
@@ -1,11 +1,15 @@
 window.addEventListener('DOMContentLoaded', function(){
   const ordersBody = document.getElementById('ordersBody');
   const counterEl = document.getElementById('counterText');
+  const acceptAllBtn = document.getElementById('acceptAllBtn');
+  const noOrdersMsg = document.getElementById('noOrdersMsg');
   let map;
 
   function updateCounter(){
     const count = document.querySelectorAll('tr[data-status="Подготовлен к доставке"]').length;
     if(counterEl) counterEl.textContent = count;
+    if(acceptAllBtn) acceptAllBtn.style.display = count > 0 ? '' : 'none';
+    if(noOrdersMsg) noOrdersMsg.style.display = count > 0 ? 'none' : '';
   }
 
   function updateMarker(id, status){
@@ -61,6 +65,14 @@ window.addEventListener('DOMContentLoaded', function(){
 
   document.querySelectorAll('.deliver-btn').forEach(btn => btn.addEventListener('click', deliverHandler));
   document.querySelectorAll('.take-btn').forEach(btn => btn.addEventListener('click', takeHandler));
+
+  if(acceptAllBtn){
+    acceptAllBtn.addEventListener('click', function(){
+      fetch('/courier/accept_all', {method:'POST'})
+        .then(r=>r.json())
+        .then(data=>{ if(data.success){ window.location.reload(); } });
+    });
+  }
 
   // map init
   const mapEl = document.getElementById('courierMap');

--- a/templates/courier.html
+++ b/templates/courier.html
@@ -8,10 +8,17 @@
   <li class="nav-item" role="presentation">
     <button class="nav-link" id="map-tab" data-bs-toggle="tab" data-bs-target="#tabMap" type="button" role="tab">Карта</button>
   </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="delivered-tab" data-bs-toggle="tab" data-bs-target="#tabDelivered" type="button" role="tab">Доставленные</button>
+  </li>
 </ul>
 <div class="tab-content pt-3">
   <div class="tab-pane fade show active" id="tabOrders" role="tabpanel">
     <h5 class="mb-3">Заказов к выдаче: <span id="counterText">{{ prepared_count }}</span></h5>
+    <p id="noOrdersMsg"{% if prepared_count > 0 %} class="d-none"{% endif %}>Нет заказов к выдаче.</p>
+    {% if prepared_count > 0 %}
+    <button id="acceptAllBtn" class="btn btn-primary mb-3">Принять все в работу</button>
+    {% endif %}
     <div class="table-responsive">
       <table class="table table-striped">
         <thead><tr><th></th><th>№</th><th>Адрес</th><th class="text-center">Статус</th><th class="text-center">Действия</th></tr></thead>
@@ -39,6 +46,18 @@
   </div>
   <div class="tab-pane fade" id="tabMap" role="tabpanel">
     <div id="courierMap" style="width:100%;height:400px;"></div>
+  </div>
+  <div class="tab-pane fade" id="tabDelivered" role="tabpanel">
+    <div class="table-responsive">
+      <table class="table table-striped">
+        <thead><tr><th>№</th><th>Адрес</th><th>Дата доставки</th></tr></thead>
+        <tbody>
+        {% for o in delivered_orders %}
+          <tr><td>{{ o.order_number }}</td><td>{{ o.address }}</td><td>{{ o.delivered_at }}</td></tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add list of delivered orders to courier dashboard
- allow courier to accept all prepared orders at once
- update interface with button and new tab
- support button logic in JS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b27d88f4832c8ae9a223364e5916