### PR TITLE
Add responsive styling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -10,7 +10,75 @@ body { padding-top: 0; }
   margin-top: 1rem;
 }
 
+.map-responsive {
+  width: 100%;
+  height: 400px;
+}
+
+.full-screen-map {
+  height: 80vh;
+}
+
 .leaflet-map {
   width: 100%;
   height: 100%;
+}
+
+@media (max-width:768px) {
+  body { font-size: 14px; }
+  .table-responsive {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+  }
+  .table-responsive table,
+  .table-responsive thead,
+  .table-responsive tbody,
+  .table-responsive th,
+  .table-responsive td,
+  .table-responsive tr {
+    display: block;
+  }
+  .table-responsive thead tr {
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
+  }
+  .table-responsive tr {
+    margin-bottom: 0.75rem;
+    border-bottom: 1px solid #ddd;
+    padding: 0.5rem;
+  }
+  .table-responsive td {
+    border: none;
+    position: relative;
+    padding-left: 50%;
+  }
+  .table-responsive td::before {
+    position: absolute;
+    top: 0;
+    left: 0.5rem;
+    width: 45%;
+    padding-right: 0.5rem;
+    white-space: nowrap;
+    font-weight: bold;
+    content: attr(data-label);
+  }
+  .table-responsive .btn {
+    width: 100%;
+    margin-bottom: 0.5rem;
+  }
+  .table-responsive .coords-cell,
+  .table-responsive .comment-cell {
+    display: none;
+  }
+  .map-container {
+    height: 60vh;
+  }
+  .map-responsive {
+    height: 60vh;
+  }
+  .full-screen-map {
+    height: 100vh;
+  }
 }

--- a/templates/courier.html
+++ b/templates/courier.html
@@ -18,15 +18,15 @@
         <tbody id="ordersBody">
         {% for o in orders %}
           <tr data-id="{{ o.id }}" data-status="{{ o.status }}">
-            <td>
+            <td data-label="">
               {% if o.status == 'Подготовлен к доставке' %}
               <button class="btn btn-sm btn-primary take-btn">Принять в работу</button>
               {% endif %}
             </td>
-            <td>{{ o.order_number }}</td>
-            <td>{{ o.address }}</td>
-            <td class="status-cell">{{ o.status }}</td>
-            <td class="actions">
+            <td data-label="№">{{ o.order_number }}</td>
+            <td data-label="Адрес">{{ o.address }}</td>
+            <td class="status-cell" data-label="Статус">{{ o.status }}</td>
+            <td class="actions" data-label="Действия">
               {% if o.status == 'Выдано на доставку' %}
               <button class="btn btn-sm btn-success deliver-btn">Доставлен</button>
               {% endif %}
@@ -38,7 +38,7 @@
     </div>
   </div>
   <div class="tab-pane fade" id="tabMap" role="tabpanel">
-    <div id="courierMap" style="width:100%;height:400px;"></div>
+    <div id="courierMap" class="map-responsive"></div>
   </div>
 </div>
 {% endblock %}

--- a/templates/map.html
+++ b/templates/map.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Карта заказов</h2>
-<div class="map-container">
+<div class="map-container full-screen-map">
   <div id="map" class="leaflet-map"></div>
 </div>
 {% endblock %}

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -44,12 +44,12 @@
           <tbody>
             {% for o in lst %}
             <tr data-id="{{ o.id }}" class="{% if not o.zone %}table-warning{% endif %}">
-              <td>{{ o.id }}</td>
-              <td>{{ o.order_number }}</td>
-              <td>{{ o.client_name }}</td>
-              <td>{{ o.phone }}</td>
-              <td>{{ o.address }}</td>
-              <td>
+              <td data-label="ID">{{ o.id }}</td>
+              <td data-label="№">{{ o.order_number }}</td>
+              <td data-label="Клиент">{{ o.client_name }}</td>
+              <td data-label="Телефон">{{ o.phone }}</td>
+              <td data-label="Адрес">{{ o.address }}</td>
+              <td data-label="Статус">
                 {% set status_class = {
                     'Складская обработка':'bg-secondary',
                     'Подготовлен к доставке':'bg-info',
@@ -70,12 +70,12 @@
                   </form>
                 </div>
               </td>
-              <td class="coords-cell">
+              <td class="coords-cell" data-label="Координаты">
                 {% if o.latitude and o.longitude %}✔{% else %}✘{% if not o.zone %} <button class="btn btn-sm btn-outline-primary" onclick="openMapModal({{ o.id }})">Указать точку</button>{% else %} <a href="{{ url_for('set_coords', order_id=o.id) }}" class="btn btn-sm btn-outline-primary ms-2">Установить на карте</a>{% endif %}{% endif %}
               </td>
-              <td class="zone-cell">{{ o.zone or 'Не определена' }}</td>
-              <td class="courier-cell">{{ o.courier.name if o.courier else '—' }}</td>
-              <td>
+              <td class="zone-cell" data-label="Зона доставки">{{ o.zone or 'Не определена' }}</td>
+              <td class="courier-cell" data-label="Курьер">{{ o.courier.name if o.courier else '—' }}</td>
+              <td class="comment-cell" data-label="Комментарий / Фото">
                 {% if o.comment %}<div>{{ o.comment }}</div>{% endif %}
                 {% if o.photo_filename %}<a href="{{ url_for('static', filename='uploads/' + o.photo_filename) }}" target="_blank">Фото</a>{% endif %}
                 {% if current_user.role == 'courier' %}
@@ -92,7 +92,7 @@
                 </div>
                 {% endif %}
               </td>
-              <td>
+              <td data-label="Действия">
                 <button class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#editModal{{ o.id }}">Редактировать</button>
                 <div class="modal fade" id="editModal{{ o.id }}" tabindex="-1" aria-hidden="true">
                   <div class="modal-dialog"><div class="modal-content"><form method="post" action="{{ url_for('update_order', order_id=o.id) }}">
@@ -138,12 +138,12 @@
             <tbody>
               {% for o in lst %}
               <tr data-id="{{ o.id }}" class="{% if not o.zone %}table-warning{% endif %}">
-                <td>{{ o.id }}</td>
-                <td>{{ o.order_number }}</td>
-                <td>{{ o.client_name }}</td>
-                <td>{{ o.phone }}</td>
-                <td>{{ o.address }}</td>
-                <td>
+                <td data-label="ID">{{ o.id }}</td>
+                <td data-label="№">{{ o.order_number }}</td>
+                <td data-label="Клиент">{{ o.client_name }}</td>
+                <td data-label="Телефон">{{ o.phone }}</td>
+                <td data-label="Адрес">{{ o.address }}</td>
+                <td data-label="Статус">
                   {% set status_class = {
                       'Складская обработка':'bg-secondary',
                       'Подготовлен к доставке':'bg-info',
@@ -152,11 +152,11 @@
                   } %}
                   <span class="badge {{ status_class.get(o.status, 'bg-secondary') }}">{{ o.status }}</span>
                 </td>
-                <td class="coords-cell">{% if o.latitude and o.longitude %}✔{% else %}✘{% if not o.zone %} <button class="btn btn-sm btn-outline-primary" onclick="openMapModal({{ o.id }})">Указать точку</button>{% endif %}{% endif %}</td>
-                <td class="zone-cell">{{ o.zone or 'Не определена' }}</td>
-                <td class="courier-cell">{{ o.courier.name if o.courier else '—' }}</td>
-                <td>{% if o.comment %}<div>{{ o.comment }}</div>{% endif %}{% if o.photo_filename %}<a href="{{ url_for('static', filename='uploads/' + o.photo_filename) }}" target="_blank">Фото</a>{% endif %}</td>
-                <td>
+                <td class="coords-cell" data-label="Координаты">{% if o.latitude and o.longitude %}✔{% else %}✘{% if not o.zone %} <button class="btn btn-sm btn-outline-primary" onclick="openMapModal({{ o.id }})">Указать точку</button>{% endif %}{% endif %}</td>
+                <td class="zone-cell" data-label="Зона доставки">{{ o.zone or 'Не определена' }}</td>
+                <td class="courier-cell" data-label="Курьер">{{ o.courier.name if o.courier else '—' }}</td>
+                <td class="comment-cell" data-label="Комментарий / Фото">{% if o.comment %}<div>{{ o.comment }}</div>{% endif %}{% if o.photo_filename %}<a href="{{ url_for('static', filename='uploads/' + o.photo_filename) }}" target="_blank">Фото</a>{% endif %}</td>
+                <td data-label="Действия">
                   {% if current_user.role == 'admin' %}
                   <form method="post" action="{{ url_for('delete_order', order_id=o.id) }}" class="d-inline" onsubmit="return confirm('Удалить заказ?');">
                     <button type="submit" class="btn btn-sm btn-danger">🗑 Удалить</button>

--- a/templates/users.html
+++ b/templates/users.html
@@ -8,10 +8,10 @@
   <tbody>
   {% for u in users %}
   <tr>
-    <td>{{ u.user.username }}</td>
-    <td>{{ u.user.role }}</td>
-    <td>{{ u.zones }}</td>
-    <td>
+    <td data-label="Username">{{ u.user.username }}</td>
+    <td data-label="Роль">{{ u.user.role }}</td>
+    <td data-label="Зона">{{ u.zones }}</td>
+    <td data-label="Действия">
       <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#editUserModal-{{ u.user.id }}">Редактировать</button>
       <form method="post" action="{{ url_for('delete_user', user_id=u.user.id) }}" style="display:inline;">
         <button class="btn btn-sm btn-danger" onclick="return confirm('Удалить пользователя?');" {% if u.user.role == 'admin' %}disabled{% endif %}>Удалить</button>

--- a/templates/zones.html
+++ b/templates/zones.html
@@ -10,10 +10,10 @@
     <tbody>
     {% for z in zones %}
     <tr>
-      <td>{{ z.id }}</td>
-      <td>{{ z.name }}</td>
-      <td><span style="background:{{ z.color }};padding:2px 10px;display:inline-block;"></span> {{ z.color }}</td>
-      <td>
+      <td data-label="ID">{{ z.id }}</td>
+      <td data-label="Название">{{ z.name }}</td>
+      <td data-label="Цвет"><span style="background:{{ z.color }};padding:2px 10px;display:inline-block;"></span> {{ z.color }}</td>
+      <td data-label="Действия">
         <a class="btn btn-sm btn-primary" href="{{ url_for('edit_zone', zone_id=z.id) }}">Редактировать</a>
         <a class="btn btn-sm btn-danger" href="{{ url_for('delete_zone', zone_id=z.id) }}" onclick="return confirm('Удалить зону?');">Удалить</a>
       </td>
@@ -22,7 +22,7 @@
     </tbody>
 </table>
 </div>
-<div class="map-container">
+<div class="map-container full-screen-map">
     <div id="zones-map" class="leaflet-map"></div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add media queries for mobile layout
- show courier and admin tables as stacked cards on small screens
- make order/map pages take most of viewport on mobile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b3315d64832c93d997e7cfa0595c