### PR TITLE
Add problem order status with reporting

### DIFF
--- a/models.py
+++ b/models.py
@@ -24,6 +24,7 @@ class Order(db.Model):
     zone = db.Column(db.String(64))
     delivered_at = db.Column(db.Date)
     comment = db.Column(db.Text)
+    problem_comment = db.Column(db.Text)
     photo_filename = db.Column(db.String(128))
     courier_id = db.Column(db.Integer, db.ForeignKey("couriers.id"))
     courier = db.relationship("Courier", backref="orders")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests
 flask-socketio
 eventlet
 flask-migrate
+pandas

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,6 +24,7 @@
       <li><a class="nav-link" href="{{ url_for('zones') }}">Зоны доставки</a></li>
       <li><a class="nav-link" href="{{ url_for('users') }}">Пользователи</a></li>
       <li><a class="nav-link" href="{{ url_for('stats') }}">Статистика</a></li>
+      <li><a class="nav-link" href="{{ url_for('reports') }}">Отчёты</a></li>
       {% endif %}
     </ul>
     <div class="mt-auto">
@@ -63,6 +64,7 @@
         <li><a class="nav-link" href="{{ url_for('zones') }}">Зоны доставки</a></li>
         <li><a class="nav-link" href="{{ url_for('users') }}">Пользователи</a></li>
         <li><a class="nav-link" href="{{ url_for('stats') }}">Статистика</a></li>
+        <li><a class="nav-link" href="{{ url_for('reports') }}">Отчёты</a></li>
         {% endif %}
         <li class="mt-3"><a class="btn btn-sm btn-outline-secondary w-100" href="{{ url_for('logout') }}">Выход</a></li>
       </ul>

--- a/templates/courier.html
+++ b/templates/courier.html
@@ -36,6 +36,7 @@
             <td class="actions" data-label="Действия">
               {% if o.status == 'Выдано на доставку' %}
               <button class="btn btn-sm btn-success deliver-btn">Доставлен</button>
+              <button class="btn btn-sm btn-danger problem-btn ms-1">Проблема</button>
               {% endif %}
             </td>
           </tr>

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -54,7 +54,8 @@
                     'Складская обработка':'bg-secondary',
                     'Подготовлен к доставке':'bg-info',
                     'Выдано на доставку':'bg-warning',
-                    'Доставлен':'bg-success'
+                    'Доставлен':'bg-success',
+                    'Проблема':'bg-danger'
                 } %}
                 <span class="badge {{ status_class.get(o.status, 'bg-secondary') }}">{{ o.status }}</span>
                 <button class="btn btn-sm btn-link p-0 ms-2" type="button" data-bs-toggle="collapse" data-bs-target="#statusForm{{ o.id }}">Изменить</button>
@@ -62,7 +63,7 @@
                   <form method="post" class="d-flex">
                     <input type="hidden" name="id" value="{{ o.id }}">
                     <select name="status" class="form-select form-select-sm me-2">
-                      {% for st in ['Складская обработка','Подготовлен к доставке','Выдано на доставку','Доставлен'] %}
+                      {% for st in ['Складская обработка','Подготовлен к доставке','Выдано на доставку','Доставлен','Проблема'] %}
                       <option value="{{ st }}" {% if o.status==st %}selected{% endif %}>{{ st }}</option>
                       {% endfor %}
                     </select>
@@ -148,7 +149,8 @@
                       'Складская обработка':'bg-secondary',
                       'Подготовлен к доставке':'bg-info',
                       'Выдано на доставку':'bg-warning',
-                      'Доставлен':'bg-success'
+                      'Доставлен':'bg-success',
+                      'Проблема':'bg-danger'
                   } %}
                   <span class="badge {{ status_class.get(o.status, 'bg-secondary') }}">{{ o.status }}</span>
                 </td>

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -1,0 +1,40 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Отчёты</h2>
+<form id="reportRange" class="row g-2 mb-3">
+  <div class="col-auto">
+    <label class="form-label">С</label>
+    <input type="date" id="repStart" class="form-control" value="{{ start }}">
+  </div>
+  <div class="col-auto">
+    <label class="form-label">По</label>
+    <input type="date" id="repEnd" class="form-control" value="{{ end }}">
+  </div>
+  <div class="col-auto align-self-end">
+    <button class="btn btn-success me-2" id="downloadDeliveredBtn">Скачать доставленные</button>
+    <button class="btn btn-danger" id="downloadProblemBtn">Скачать проблемные</button>
+  </div>
+</form>
+{% endblock %}
+{% block scripts %}
+<script>
+ document.addEventListener('DOMContentLoaded', function(){
+   function download(type){
+     const s = document.getElementById('repStart').value;
+     const e = document.getElementById('repEnd').value;
+     const params = new URLSearchParams();
+     if(s) params.append('start', s);
+     if(e) params.append('end', e);
+     window.location = `/reports/export/${type}?` + params.toString();
+   }
+   document.getElementById('downloadDeliveredBtn').addEventListener('click', function(ev){
+     ev.preventDefault();
+     download('delivered');
+   });
+   document.getElementById('downloadProblemBtn').addEventListener('click', function(ev){
+     ev.preventDefault();
+     download('problem');
+   });
+ });
+</script>
+{% endblock %}

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -1,89 +1,76 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>Статистика доставок</h2>
-<form class="row g-2 mb-3" id="filters">
+<h2>Статистика</h2>
+<form id="statsRange" class="row g-2 mb-3">
   <div class="col-auto">
-    <label class="form-label">Период</label>
-    <select id="period" class="form-select">
-      <option value="today">Сегодня</option>
-      <option value="week">Неделя</option>
-      <option value="month">Месяц</option>
-      <option value="all">Все</option>
-    </select>
+    <label class="form-label">С</label>
+    <input type="date" id="statStart" class="form-control">
   </div>
   <div class="col-auto">
-    <label class="form-label">Зона</label>
-    <select id="zone" class="form-select">
-      <option value="">Все</option>
-      {% for z in zones %}
-      <option value="{{ z.name }}">{{ z.name }}</option>
-      {% endfor %}
-    </select>
-  </div>
-  <div class="col-auto">
-    <label class="form-label">Курьер</label>
-    <select id="courier" class="form-select">
-      <option value="">Все</option>
-      {% for c in couriers %}
-      <option value="{{ c.id }}">{{ c.name }}</option>
-      {% endfor %}
-    </select>
+    <label class="form-label">По</label>
+    <input type="date" id="statEnd" class="form-control">
   </div>
   <div class="col-auto align-self-end">
-    <button class="btn btn-primary" id="applyFilters">Применить</button>
+    <button class="btn btn-primary" id="applyStats">Применить</button>
   </div>
 </form>
-<canvas id="ordersChart" height="100"></canvas>
-<canvas id="zoneChart" height="100" class="mt-4"></canvas>
+<div id="metrics" class="row row-cols-2 row-cols-md-4 g-2 mb-3">
+  <div class="col"><div class="card text-center"><div class="card-body"><div class="h4" id="deliveredCount">0</div><div>Доставлено</div></div></div></div>
+  <div class="col"><div class="card text-center"><div class="card-body"><div class="h4" id="inWorkCount">0</div><div>В работе</div></div></div></div>
+  <div class="col"><div class="card text-center"><div class="card-body"><div class="h4" id="preparedCount">0</div><div>Подготовлено</div></div></div></div>
+  <div class="col"><div class="card text-center"><div class="card-body"><div class="h4" id="problemCount">0</div><div>Проблемные</div></div></div></div>
+</div>
+<canvas id="statusChart" height="200"></canvas>
+<div class="mt-3">
+  <button class="btn btn-success" id="downloadFull">Скачать полный отчёт</button>
+</div>
 {% endblock %}
 {% block scripts %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
-document.addEventListener('DOMContentLoaded', function(){
-  let lineChart, pieChart;
-  function loadData(){
-    const params = new URLSearchParams();
-    params.append('period', document.getElementById('period').value);
-    const zone = document.getElementById('zone').value;
-    if(zone) params.append('zone', zone);
-    const courier = document.getElementById('courier').value;
-    if(courier) params.append('courier', courier);
-    fetch('{{ url_for('stats_data') }}?' + params.toString())
-      .then(r => r.json())
-      .then(updateCharts);
-  }
-  function updateCharts(data){
-    const ctx = document.getElementById('ordersChart').getContext('2d');
-    if(lineChart) lineChart.destroy();
-    lineChart = new Chart(ctx, {
-      type: 'line',
-      data: {
-        labels: data.dates,
-        datasets: [{
-          label: 'Доставленные заказы',
-          data: data.counts,
-          borderColor: 'rgb(75,192,192)',
-          tension: 0.1
-        }]
-      }
-    });
-    const pctx = document.getElementById('zoneChart').getContext('2d');
-    if(pieChart) pieChart.destroy();
-    pieChart = new Chart(pctx, {
-      type: 'pie',
-      data: {
-        labels: data.zone_labels,
-        datasets: [{
-          data: data.zone_counts
-        }]
-      }
-    });
-  }
-  document.getElementById('applyFilters').addEventListener('click', function(e){
-    e.preventDefault();
-    loadData();
-  });
-  loadData();
-});
+ document.addEventListener('DOMContentLoaded', function(){
+   const today = new Date();
+   const startInput = document.getElementById('statStart');
+   const endInput = document.getElementById('statEnd');
+   startInput.value = new Date(today.getFullYear(), today.getMonth(), 1).toISOString().slice(0,10);
+   endInput.value = today.toISOString().slice(0,10);
+   let barChart;
+   function loadData(){
+     const params = new URLSearchParams();
+     if(startInput.value) params.append('start', startInput.value);
+     if(endInput.value) params.append('end', endInput.value);
+     fetch('{{ url_for('stats_data') }}?' + params.toString())
+       .then(r=>r.json())
+       .then(update);
+   }
+   function update(data){
+     document.getElementById('deliveredCount').textContent = data.delivered;
+     document.getElementById('inWorkCount').textContent = data.out_for_delivery;
+     document.getElementById('preparedCount').textContent = data.prepared;
+     document.getElementById('problemCount').textContent = data.problem;
+     const ctx = document.getElementById('statusChart').getContext('2d');
+     if(barChart) barChart.destroy();
+     barChart = new Chart(ctx, {
+       type:'bar',
+       data:{
+         labels:['Подготовлено','В работе','Доставлено','Проблема'],
+         datasets:[{data:[data.prepared,data.out_for_delivery,data.delivered,data.problem],backgroundColor:['blue','orange','green','red']}]
+       },
+       options:{indexAxis:'y', responsive:true, maintainAspectRatio:false}
+     });
+   }
+   document.getElementById('applyStats').addEventListener('click', function(ev){
+     ev.preventDefault();
+     loadData();
+   });
+   document.getElementById('downloadFull').addEventListener('click', function(ev){
+     ev.preventDefault();
+     const params = new URLSearchParams();
+     if(startInput.value) params.append('start', startInput.value);
+     if(endInput.value) params.append('end', endInput.value);
+     window.location = '/reports/export/all?' + params.toString();
+   });
+   loadData();
+ });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- support problem orders via new status and comment field
- add reports page with export buttons
- extend courier workflow for problem orders
- show new metrics and horizontal bar chart in stats
- add pandas dependency for Excel export

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855bf1c74e8832ca6b3a46b924e8091