### PR TITLE
Add problem_comment column

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,7 +42,7 @@ from flask_login import (
     logout_user,
 )
 from flask_migrate import Migrate
-from sqlalchemy import func, inspect
+from sqlalchemy import func, inspect, text
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from config import Config
@@ -206,6 +206,8 @@ def populate_demo_data():
 
 with app.app_context():
     db.create_all()
+    with db.engine.connect() as conn:
+        conn.execute(text("ALTER TABLE orders ADD COLUMN problem_comment TEXT"))
     populate_demo_data()
 
 

--- a/migrations/versions/4c8e74d5d1f3_add_problem_comment.py
+++ b/migrations/versions/4c8e74d5d1f3_add_problem_comment.py
@@ -1,0 +1,22 @@
+"""add problem_comment to orders
+
+Revision ID: 4c8e74d5d1f3
+Revises: 8922a5ebcd01
+Create Date: 2025-06-21 00:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '4c8e74d5d1f3'
+down_revision = '8922a5ebcd01'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    with op.batch_alter_table('orders', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('problem_comment', sa.Text()))
+
+def downgrade():
+    with op.batch_alter_table('orders', schema=None) as batch_op:
+        batch_op.drop_column('problem_comment')


### PR DESCRIPTION
## Summary
- add missing problem_comment in orders table at startup
- include a migration script for the new column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c2a2a360832cb1f92c938a889d11