### PR TITLE
Update reports to filter by import batch

### DIFF
--- a/templates/reports.html
+++ b/templates/reports.html
@@ -3,12 +3,12 @@
 <h2>Отчёты</h2>
 <form id="reportRange" class="row g-2 mb-3">
   <div class="col-auto">
-    <label class="form-label">С</label>
-    <input type="date" id="repStart" class="form-control" value="{{ start }}">
-  </div>
-  <div class="col-auto">
-    <label class="form-label">По</label>
-    <input type="date" id="repEnd" class="form-control" value="{{ end }}">
+    <label class="form-label">Партия импорта</label>
+    <select id="batchSelect" class="form-select">
+      {% for b in batches %}
+      <option value="{{ b }}">{{ b }}</option>
+      {% endfor %}
+    </select>
   </div>
   <div class="col-auto align-self-end">
     <button class="btn btn-success me-2" id="downloadDeliveredBtn">Скачать доставленные</button>
@@ -20,12 +20,11 @@
 <script>
  document.addEventListener('DOMContentLoaded', function(){
    function download(type){
-     const s = document.getElementById('repStart').value;
-     const e = document.getElementById('repEnd').value;
+     const batch = document.getElementById('batchSelect').value;
+     if(!batch) return;
      const params = new URLSearchParams();
-     if(s) params.append('start', s);
-     if(e) params.append('end', e);
-     window.location = `/reports/export/${type}?` + params.toString();
+     params.append('batch', batch);
+     window.location = `/download/${type}?` + params.toString();
    }
    document.getElementById('downloadDeliveredBtn').addEventListener('click', function(ev){
      ev.preventDefault();


### PR DESCRIPTION
## Summary
- let the reports page fetch all unique `import_batch` values
- show a dropdown with these batches instead of start/end dates
- add routes to download delivered or problematic orders for a batch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c4a0d740832c814625db442b423d