### PR TITLE
Adjust stats chart

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -160,3 +160,11 @@ body {
 .leaflet-map {
   border-radius: 12px;
 }
+
+/* Charts */
+.chart-wrapper {
+  overflow-x: auto;
+}
+.chart-wrapper canvas {
+  display: block;
+}

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -20,7 +20,10 @@
   <div class="col"><div class="card text-center"><div class="card-body"><div class="h4" id="preparedCount">0</div><div>Подготовлено</div></div></div></div>
   <div class="col"><div class="card text-center"><div class="card-body"><div class="h4" id="problemCount">0</div><div>Проблемные</div></div></div></div>
 </div>
-<canvas id="statusChart" height="200"></canvas>
+<div class="chart-wrapper mb-3">
+  <canvas id="statusChart" width="600" height="400"></canvas>
+</div>
+<p id="noData" class="text-center d-none">Нет данных для выбранного периода.</p>
 <div class="mt-3">
   <button class="btn btn-success" id="downloadFull">Скачать полный отчёт</button>
 </div>
@@ -48,16 +51,30 @@
      document.getElementById('inWorkCount').textContent = data.out_for_delivery;
      document.getElementById('preparedCount').textContent = data.prepared;
      document.getElementById('problemCount').textContent = data.problem;
-     const ctx = document.getElementById('statusChart').getContext('2d');
-     if(barChart) barChart.destroy();
-     barChart = new Chart(ctx, {
-       type:'bar',
-       data:{
-         labels:['Подготовлено','В работе','Доставлено','Проблема'],
-         datasets:[{data:[data.prepared,data.out_for_delivery,data.delivered,data.problem],backgroundColor:['blue','orange','green','red']}]
-       },
-       options:{indexAxis:'y', responsive:true, maintainAspectRatio:false}
-     });
+
+     const total = data.prepared + data.out_for_delivery + data.delivered + data.problem;
+     const chartEl = document.getElementById('statusChart');
+     const noDataEl = document.getElementById('noData');
+     if(barChart){
+       barChart.destroy();
+       barChart = null;
+     }
+     if(total > 0){
+       chartEl.classList.remove('d-none');
+       noDataEl.classList.add('d-none');
+       const ctx = chartEl.getContext('2d');
+       barChart = new Chart(ctx, {
+         type:'bar',
+         data:{
+           labels:['Подготовлено','В работе','Доставлено','Проблема'],
+           datasets:[{data:[data.prepared,data.out_for_delivery,data.delivered,data.problem],backgroundColor:['blue','orange','green','red']}]
+         },
+         options:{indexAxis:'y', responsive:true, maintainAspectRatio:false}
+       });
+     }else{
+       chartEl.classList.add('d-none');
+       noDataEl.classList.remove('d-none');
+     }
    }
    document.getElementById('applyStats').addEventListener('click', function(ev){
      ev.preventDefault();


### PR DESCRIPTION
## Summary
- tweak stats chart visuals and height
- add CSS helpers for charts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c5289b08832cbdc56bdc1a329bb6