### PR TITLE
Add responsive styling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -168,3 +168,25 @@ body {
 .chart-wrapper canvas {
   display: block;
 }
+
+@media (max-width:768px) {
+  .menu-toggle {
+    padding: 0.5rem 1rem;
+    font-size: 1.25rem;
+  }
+  .login-card {
+    width: 90%;
+    min-width: 280px;
+    margin: 0 auto;
+  }
+  .login-card .btn {
+    width: 100%;
+  }
+  .flex-grow-1 {
+    margin-left: 0 !important;
+  }
+  #ordersTabs .nav-item,
+  #ordersTabs .nav-link {
+    width: 100%;
+  }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -72,14 +72,13 @@
   </div>
 
   <div class="flex-grow-1" style="margin-left:220px;">
-    <nav class="navbar navbar-light bg-white shadow-sm d-md-none">
-      <div class="container-fluid">
-        <button class="btn btn-primary" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasMenu">☰</button>
-        <span class="navbar-brand ms-2">CRM</span>
-        <span class="ms-auto me-2">{{ current_user.username }}</span>
-        <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('logout') }}">Выход</a>
-      </div>
-    </nav>
+      <nav class="navbar navbar-light bg-white shadow-sm d-md-none">
+        <div class="container-fluid">
+          <button class="btn btn-primary menu-toggle" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasMenu">☰</button>
+          <span class="navbar-brand ms-2">CRM</span>
+          <span class="ms-auto me-2">{{ current_user.username }}</span>
+        </div>
+      </nav>
     <div class="container-fluid pt-3">
 {% else %}
 <nav class="navbar navbar-light bg-white shadow-sm mb-3">

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <div class="row justify-content-center">
-  <div class="col-11 col-sm-8 col-md-6 col-lg-4 card">
+  <div class="col-11 col-sm-8 col-md-6 col-lg-4 card login-card">
     <h2>Вход</h2>
     <form method="post">
       <div class="mb-3">
@@ -12,7 +12,7 @@
         <label class="form-label">Пароль</label>
         <input type="password" class="form-control" name="password">
       </div>
-      <button type="submit" class="btn btn-primary">Войти</button>
+      <button type="submit" class="btn btn-primary w-100">Войти</button>
     </form>
   </div>
 </div>

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -2,13 +2,13 @@
 {% block content %}
 <h2>Заказы</h2>
 {% if current_user.role == 'admin' %}
-<a class="btn btn-sm btn-success mb-3" href="{{ url_for('import_upload') }}">Импорт заказов</a>
+<a class="btn btn-sm btn-success mb-3 w-100" href="{{ url_for('import_upload') }}">Импорт заказов</a>
 {% endif %}
 <input
   type="text"
   id="orderSearch"
   placeholder="Поиск по заказам..."
-  class="form-control mb-3"
+  class="form-control mb-3 w-100"
 />
 {% with messages = get_flashed_messages(with_categories=true) %}
   {% if messages %}


### PR DESCRIPTION
## Summary
- make sidebar margin mobile-friendly
- enlarge menu button and move logout into drawer only
- center login form with wider button
- improve orders page mobile layout
- tweak styles for small screens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68565d8779d0832c845ca154cb57e433