### PR TITLE
Switch to PostgreSQL via DATABASE_URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 database.db
+db.sqlite3
 uploads/

--- a/app.py
+++ b/app.py
@@ -207,12 +207,13 @@ def populate_demo_data():
 
 with app.app_context():
     db.create_all()
-    with db.engine.connect() as conn:
-        table_info = conn.execute(text("PRAGMA table_info(orders)")).fetchall()
-        column_names = [col[1] for col in table_info]
+    if db.engine.url.drivername.startswith("sqlite"):
+        with db.engine.connect() as conn:
+            table_info = conn.execute(text("PRAGMA table_info(orders)")).fetchall()
+            column_names = [col[1] for col in table_info]
 
-        if "problem_comment" not in column_names:
-            conn.execute(text("ALTER TABLE orders ADD COLUMN problem_comment TEXT"))
+            if "problem_comment" not in column_names:
+                conn.execute(text("ALTER TABLE orders ADD COLUMN problem_comment TEXT"))
     populate_demo_data()
 
 

--- a/config.py
+++ b/config.py
@@ -4,7 +4,6 @@ BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
 class Config:
     SECRET_KEY = os.environ.get('SECRET_KEY', 'secret')
-    SQLALCHEMY_DATABASE_URI = os.environ.get(
-        'DATABASE_URL', f"sqlite:///{os.path.join(BASE_DIR, 'database.db')}")
+    SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URL")
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     UPLOAD_FOLDER = os.path.join(BASE_DIR, 'uploads')


### PR DESCRIPTION
## Summary
- configure SQLAlchemy to use `DATABASE_URL`
- skip SQLite-specific migration when running against PostgreSQL
- ignore `db.sqlite3`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68566e5ff918832c991fdef86dba949e