### PR TITLE
Add compatibility for Fly.io DB env

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,9 @@
 import os
 
+# Ensure compatibility between platform environment variables
+if "SQLALCHEMY_DATABASE_URI" in os.environ and "DATABASE_URL" not in os.environ:
+    os.environ["DATABASE_URL"] = os.environ["SQLALCHEMY_DATABASE_URI"]
+
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
 class Config:


### PR DESCRIPTION
## Summary
- support `SQLALCHEMY_DATABASE_URI` when `DATABASE_URL` is missing

## Testing
- `pip install Flask SQLAlchemy Flask-SQLAlchemy Flask-Login pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856d62d0df8832c995b0831f719da5d