### PR TITLE
Fix config to use DB URI from env

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,16 +1,10 @@
 import os
 
-# Ensure compatibility between platform environment variables
-if "SQLALCHEMY_DATABASE_URI" in os.environ and "DATABASE_URL" not in os.environ:
-    os.environ["DATABASE_URL"] = os.environ["SQLALCHEMY_DATABASE_URI"]
-
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
+
 class Config:
-    SECRET_KEY = os.environ.get('SECRET_KEY', 'secret')
-url = os.environ.get("DATABASE_URL") or "sqlite:///database.db"
-if url.startswith("postgres://"):
-    url = url.replace("postgres://", "postgresql://", 1)
-SQLALCHEMY_DATABASE_URI = url
-SQLALCHEMY_TRACK_MODIFICATIONS = False
-UPLOAD_FOLDER = os.path.join(BASE_DIR, 'uploads')
+    SECRET_KEY = os.environ.get("SECRET_KEY", "secret")
+    SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI")
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    UPLOAD_FOLDER = os.path.join(BASE_DIR, "uploads")


### PR DESCRIPTION
## Summary
- simplify `Config` to read `SQLALCHEMY_DATABASE_URI` directly from environment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857115d35d8832c846ffe3e2fe3f537