### PR TITLE
Fix env variable loading for DB URI

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,6 +5,6 @@ BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
 class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY", "secret")
-    SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI")
+    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     UPLOAD_FOLDER = os.path.join(BASE_DIR, "uploads")


### PR DESCRIPTION
## Summary
- ensure `SQLALCHEMY_DATABASE_URI` is read from the environment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685714573e6c832c91b7f64a5597a947