### PR TITLE
Increase password hash length

### DIFF
--- a/migrations/versions/00dad933315d_increase_password_hash_length.py
+++ b/migrations/versions/00dad933315d_increase_password_hash_length.py
@@ -1,0 +1,30 @@
+"""increase password_hash length
+
+Revision ID: 00dad933315d
+Revises: 4c8e74d5d1f3
+Create Date: 2025-06-21 20:51:20.794097
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '00dad933315d'
+down_revision = '4c8e74d5d1f3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.alter_column('password_hash',
+               existing_type=sa.String(length=128),
+               type_=sa.String(length=512),
+               existing_nullable=False)
+
+
+def downgrade():
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.alter_column('password_hash',
+               existing_type=sa.String(length=512),
+               type_=sa.String(length=128),
+               existing_nullable=False)

--- a/models.py
+++ b/models.py
@@ -50,7 +50,7 @@ class User(db.Model, UserMixin):
     __tablename__ = "users"
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(64), unique=True, nullable=False)
-    password_hash = db.Column(db.String(128), nullable=False)
+    password_hash = db.Column(db.String(512), nullable=False)
     role = db.Column(db.String(16), nullable=False)
 
 


### PR DESCRIPTION
## Summary
- extend `User.password_hash` to 512 characters
- add Alembic migration to update existing DB column

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68571a736224832c8241a728c2cef485