### PR TITLE
Add backup script and fix point selection

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+BACKUP_DIR="/backups"
+mkdir -p "$BACKUP_DIR"
+DATE=$(date +%F)
+FILE="$BACKUP_DIR/backup-$DATE.sql"
+pg_dump postgresql://appuser:StrongPass123@dilivery-db.flycast:5432/postgres > "$FILE"
+# keep last 7 backups
+ls -1t "$BACKUP_DIR"/backup-*.sql 2>/dev/null | tail -n +8 | xargs -r rm --

--- a/fly.toml
+++ b/fly.toml
@@ -19,6 +19,14 @@ PORT = "5000"
   min_machines_running = 0
   processes = ['app']
 
+[[mounts]]
+  source = "backups"
+  destination = "/backups"
+
+[[cron]]
+  schedule = "0 2 * * *"
+  command = "/backup.sh"
+
 [[vm]]
   memory = '1gb'
   cpu_kind = 'shared'

--- a/static/js/orders.js
+++ b/static/js/orders.js
@@ -39,7 +39,7 @@ function openMapModal(orderId) {
     if (window.zonesData) {
         window.zonesData.forEach(z => {
             if (z.polygon && z.polygon.length) {
-                const poly = L.polygon(z.polygon.map(p => [p[1], p[0]]), {color: z.color});
+                const poly = L.polygon(z.polygon.map(p => [p[1], p[0]]), {color: z.color, interactive:false});
                 poly.bindPopup(z.name);
                 group.addLayer(poly);
             }

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -73,7 +73,7 @@ document.addEventListener('DOMContentLoaded', function(){
     if(window.zonesData){
       window.zonesData.forEach(function(z){
         if(z.polygon && z.polygon.length){
-          var poly = L.polygon(z.polygon.map(function(p){return [p[1], p[0]];}), {color:z.color});
+          var poly = L.polygon(z.polygon.map(function(p){return [p[1], p[0]];}), {color:z.color, interactive:false});
           poly.bindPopup(z.name);
           group.addLayer(poly);
         }

--- a/templates/set_coords.html
+++ b/templates/set_coords.html
@@ -24,7 +24,7 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 var group = L.featureGroup().addTo(map);
 zones.forEach(function(z){
     if(z.polygon && z.polygon.length){
-        var poly = L.polygon(z.polygon.map(function(p){return [p[1], p[0]];}), {color:z.color});
+        var poly = L.polygon(z.polygon.map(function(p){return [p[1], p[0]];}), {color:z.color, interactive:false});
         poly.bindPopup(z.name);
         group.addLayer(poly);
     }


### PR DESCRIPTION
## Summary
- add `backup.sh` to keep seven daily database dumps
- mount `/backups` and schedule daily backup cron in `fly.toml`
- stop zone polygons from blocking clicks on order maps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68571e799154832c90880912ea1b8ef4