### PR TITLE
Add clear orders option with sequence reset

### DIFF
--- a/templates/import_mapping.html
+++ b/templates/import_mapping.html
@@ -6,6 +6,10 @@
     <input class="form-check-input" type="checkbox" id="headerCheck" name="header" checked>
     <label class="form-check-label" for="headerCheck">Первая строка содержит заголовки</label>
   </div>
+  <div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" id="clearCheck" name="clear" value="1">
+    <label class="form-check-label" for="clearCheck">Очистить старые данные</label>
+  </div>
   <table class="table table-sm">
     <thead>
       <tr>


### PR DESCRIPTION
## Summary
- support clearing existing orders before import and reset the sequence
- expose the clear option in import UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857668827e8832ca3a757ce41e12b90