### PR TITLE
Implement local order numbering

### DIFF
--- a/migrations/versions/d4419d51f884_add_import_id_and_local_order_number.py
+++ b/migrations/versions/d4419d51f884_add_import_id_and_local_order_number.py
@@ -1,0 +1,25 @@
+"""add import_id and local_order_number
+
+Revision ID: d4419d51f884
+Revises: 00dad933315d
+Create Date: 2025-06-22 00:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'd4419d51f884'
+down_revision = '00dad933315d'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    with op.batch_alter_table('orders', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('import_id', postgresql.UUID(as_uuid=True), nullable=True))
+        batch_op.add_column(sa.Column('local_order_number', sa.Integer(), nullable=True))
+
+def downgrade():
+    with op.batch_alter_table('orders', schema=None) as batch_op:
+        batch_op.drop_column('local_order_number')
+        batch_op.drop_column('import_id')

--- a/models.py
+++ b/models.py
@@ -18,6 +18,8 @@ class Order(db.Model):
     address = db.Column(db.String(256))
     note = db.Column(db.Text)
     import_batch = db.Column(db.String(64))
+    import_id = db.Column(UUID(as_uuid=True))
+    local_order_number = db.Column(db.Integer)
     status = db.Column(db.String(64), default="Складская обработка")
     latitude = db.Column(db.Float)
     longitude = db.Column(db.Float)

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -28,7 +28,7 @@
     {% for batch, lst in orders_by_batch.items() %}
     <details class="mb-3" {% if loop.last %}open{% endif %}>
       <summary class="h5 d-flex justify-content-between align-items-center">
-        <span>Импорт: {{ batch }}</span>
+        <span>Импорт: {{ import_ids.get(batch, batch) }}</span>
         {% if current_user.role == 'admin' %}
         <form method="post" action="/orders/delete_table" class="d-inline" onsubmit="return confirm('Удалить ВСЮ таблицу?');">
           <input type="hidden" name="batch" value="{{ batch }}">
@@ -44,7 +44,7 @@
           <tbody>
             {% for o in lst %}
             <tr data-id="{{ o.id }}" class="{% if not o.zone %}table-warning{% endif %}">
-              <td data-label="ID">{{ o.id }}</td>
+              <td data-label="ID">{{ o.local_order_number }}</td>
               <td data-label="№">{{ o.order_number }}</td>
               <td data-label="Клиент">{{ o.client_name }}</td>
               <td data-label="Телефон">{{ o.phone }}</td>
@@ -139,7 +139,7 @@
             <tbody>
               {% for o in lst %}
               <tr data-id="{{ o.id }}" class="{% if not o.zone %}table-warning{% endif %}">
-                <td data-label="ID">{{ o.id }}</td>
+                <td data-label="ID">{{ o.local_order_number }}</td>
                 <td data-label="№">{{ o.order_number }}</td>
                 <td data-label="Клиент">{{ o.client_name }}</td>
                 <td data-label="Телефон">{{ o.phone }}</td>


### PR DESCRIPTION
## Summary
- assign sequential local order numbers when importing orders
- store `import_id` and local number in DB
- show local order numbers in the orders table and display import UUID
- add Alembic migration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68576af6eb44832c81e68ce242a380cb