### PR TITLE
Add import_id field to Order

### DIFF
--- a/migrations/versions/a5d7000c64c3_add_import_id_column.py
+++ b/migrations/versions/a5d7000c64c3_add_import_id_column.py
@@ -1,0 +1,26 @@
+"""add import_id column
+
+Revision ID: a5d7000c64c3
+Revises: d4419d51f884
+Create Date: 2025-06-22 02:53:52.069652
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a5d7000c64c3'
+down_revision = 'd4419d51f884'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('orders', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('import_id', sa.String(length=36), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('orders', schema=None) as batch_op:
+        batch_op.drop_column('import_id')

--- a/models.py
+++ b/models.py
@@ -18,7 +18,7 @@ class Order(db.Model):
     address = db.Column(db.String(256))
     note = db.Column(db.Text)
     import_batch = db.Column(db.String(64))
-    import_id = db.Column(UUID(as_uuid=True))
+    import_id = db.Column(db.String(36), nullable=True)
     local_order_number = db.Column(db.Integer)
     status = db.Column(db.String(64), default="Складская обработка")
     latitude = db.Column(db.Float)


### PR DESCRIPTION
## Summary
- add `import_id` field to `Order`
- create Alembic migration to add the new column

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68576f8cd4bc832c913ad44ee6dcd8e7