### PR TITLE
Fix SQLAlchemy URI env variable

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,7 +55,7 @@ from models import Courier, DeliveryZone, ImportJob, Order, User, db
 
 app = Flask(__name__)
 app.config.from_object(Config)
-app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL')
+app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('SQLALCHEMY_DATABASE_URI')
 
 db.init_app(app)
 migrate = Migrate(app, db)


### PR DESCRIPTION
## Summary
- correct SQLAlchemy config key

## Testing
- `pytest -q`
- `SQLALCHEMY_DATABASE_URI=sqlite:///:memory: python app.py` *(terminated after launch)*


------
https://chatgpt.com/codex/tasks/task_e_685805997d1c832ca7666e9d134c030c