### PR TITLE
Fix Fly.io DB URL initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ python app.py
 
 Demo data are no longer generated automatically. Create your own zones, couriers and orders manually. Configuration values can be changed in `config.py` or via environment variables.
 
+The app reads the database connection string from the `DATABASE_URL` environment variable. If the URL uses the legacy `postgres://` scheme it will be converted to `postgresql://` as required by SQLAlchemy.
+
 If you are upgrading from previous versions remove the old SQLite database so that the new
 `ImportJob` id format is applied:
 

--- a/app.py
+++ b/app.py
@@ -55,8 +55,16 @@ from models import Courier, DeliveryZone, ImportJob, Order, User, db
 
 app = Flask(__name__)
 app.config.from_object(Config)
-app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get("SQLALCHEMY_DATABASE_URI")
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+database_url = os.getenv("DATABASE_URL")
+if not database_url:
+    print("❌ DATABASE_URL environment variable is not set")
+    raise SystemExit(1)
+if database_url.startswith("postgres://"):
+    database_url = database_url.replace("postgres://", "postgresql://", 1)
+
+app.config["SQLALCHEMY_DATABASE_URI"] = database_url
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
 db.init_app(app)
 migrate = Migrate(app, db)

--- a/config.py
+++ b/config.py
@@ -5,6 +5,5 @@ BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
 class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY", "secret")
-    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     UPLOAD_FOLDER = os.path.join(BASE_DIR, "uploads")


### PR DESCRIPTION
## Summary
- resolve DATABASE_URL reading in `app.py`
- drop unused SQLALCHEMY_DATABASE_URI from config
- clarify database URL requirement in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68580acb0f3c832cbea967db74342889