### PR TITLE
Fix database config from environment

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,7 +56,9 @@ from models import Courier, DeliveryZone, ImportJob, Order, User, db
 app = Flask(__name__)
 app.config.from_object(Config)
 
-database_url = os.getenv("DATABASE_URL")
+# Configure the database connection from environment variables
+app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv("SQLALCHEMY_DATABASE_URI") or os.getenv("DATABASE_URL")
+database_url = app.config["SQLALCHEMY_DATABASE_URI"]
 if not database_url:
     print("❌ DATABASE_URL environment variable is not set")
     raise SystemExit(1)


### PR DESCRIPTION
## Summary
- configure SQLALCHEMY_DATABASE_URI from `SQLALCHEMY_DATABASE_URI` or `DATABASE_URL`
- keep fallback conversion for legacy `postgres://` URLs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580d69263c832c99dee626399c2975