### PR TITLE
Fix DB config for Fly.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ python app.py
 
 Demo data are no longer generated automatically. Create your own zones, couriers and orders manually. Configuration values can be changed in `config.py` or via environment variables.
 
-The app reads the database connection string from the `DATABASE_URL` environment variable. If the URL uses the legacy `postgres://` scheme it will be converted to `postgresql://` as required by SQLAlchemy.
+The application expects the connection string in the
+`SQLALCHEMY_DATABASE_URI` environment variable. `DATABASE_URL` is also
+honoured for compatibility. Legacy `postgres://` URLs are automatically
+converted to `postgresql+psycopg2://` which is required by SQLAlchemy.
 
 If you are upgrading from previous versions remove the old SQLite database so that the new
 `ImportJob` id format is applied:


### PR DESCRIPTION
## Summary
- show `DB URI` value on startup
- ensure environment variables are read directly from `os.environ`
- convert legacy postgres URLs to the driver-specific format
- document `SQLALCHEMY_DATABASE_URI` variable in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580fb92424832c8749ecb1420b2a68