### PR TITLE
Fix config loading before SQLAlchemy init

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,7 +56,7 @@ from geocode import geocode_address
 from models import Courier, DeliveryZone, ImportJob, Order, User, db
 
 app = Flask(__name__)
-app.config.from_object(Config)
+app.config.from_object("config.Config")
 
 app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get("SQLALCHEMY_DATABASE_URI") or os.environ.get("DATABASE_URL")
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False


### PR DESCRIPTION
## Summary
- load Flask configuration from `config.Config` before initializing the DB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858187f5d90832c8ed1c8158d987efc