### PR TITLE
Add auto cleanup of old backups

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -7,3 +7,5 @@ FILE="$BACKUP_DIR/backup-$DATE.sql"
 pg_dump postgresql://appuser:StrongPass123@dilivery-db.flycast:5432/postgres > "$FILE"
 # keep last 7 backups
 ls -1t "$BACKUP_DIR"/backup-*.sql 2>/dev/null | tail -n +8 | xargs -r rm --
+# Delete backups older than 7 days
+find /backups -type f -name "*.sql" -mtime +7 -delete


### PR DESCRIPTION
## Summary
- add command in `backup.sh` to delete `.sql` files older than 7 days

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68583daf5dfc832cb6708a2f419b8e15