### PR TITLE
Fix engine retrieval in orders view

### DIFF
--- a/app.py
+++ b/app.py
@@ -298,7 +298,7 @@ def orders():
         if courier and courier.zones:
             allowed_zones = [z.strip() for z in courier.zones.split(",") if z.strip()]
 
-    engine = db.session.get_bind() or db.engine
+    engine = db.get_engine()
     dialect = engine.dialect.name
 
     inspector = inspect(engine)


### PR DESCRIPTION
## Summary
- call `db.get_engine()` instead of `db.session.get_bind()` in `/orders` route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685861088008832c952504d1c92e606f