### PR TITLE
Implement ImportBatch grouping in orders

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,7 +54,7 @@ from werkzeug.security import check_password_hash, generate_password_hash
 
 from config import Config
 from geocode import geocode_address
-from models import Courier, DeliveryZone, ImportJob, Order, User, db
+from models import Courier, DeliveryZone, ImportJob, Order, User, ImportBatch, db
 
 app = Flask(__name__)
 app.config.from_object("config.Config")
@@ -298,75 +298,25 @@ def orders():
         if courier and courier.zones:
             allowed_zones = [z.strip() for z in courier.zones.split(",") if z.strip()]
 
-    engine = db.get_engine()
-    dialect = engine.dialect.name
-
-    inspector = inspect(engine)
-    order_tables = []
-    if inspector.has_table(Order.__tablename__):
-        order_tables.append(Order.__tablename__)
-
-    tables = []
-    with engine.connect() as connection:
-        if dialect == "postgresql":
-            result = connection.execute(
-                text(
-                    "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename LIKE 'orders_%'"
-                )
-            )
-        elif dialect == "sqlite":
-            result = connection.execute(
-                text(
-                    "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'orders_%'"
-                )
-            )
-        else:
-            result = []
-
-        tables = [row[0] for row in result]
-
-    if tables:
-        order_tables.extend(tables)
-    else:
-        order_tables.extend(
-            t for t in inspector.get_table_names() if t.startswith("orders_")
-        )
-
     couriers_list = Courier.query.all()
     couriers_map = {c.id: c for c in couriers_list}
 
     orders_by_batch = {}
     orders_by_zone = defaultdict(list)
-    import_ids = {}
     all_orders = []
 
-    for name in order_tables:
-        if name == Order.__tablename__:
-            query = Order.query
-            if allowed_zones:
-                query = query.filter(Order.zone.in_(allowed_zones))
-            elif current_user.role == "courier":
-                query = query.filter(db.text("0=1"))
-            items = query.order_by(Order.id).all()
-        else:
-            rows = (
-                db.session.execute(text(f"SELECT * FROM {name} ORDER BY id")).mappings().all()
-            )
-            items = []
-            for r in rows:
-                if allowed_zones and (r.get("zone") not in allowed_zones):
-                    continue
-                d = dict(r)
-                d["courier"] = couriers_map.get(d.get("courier_id"))
-                items.append(SimpleNamespace(**d))
-
-        orders_by_batch[name] = items
+    batches = ImportBatch.query.order_by(ImportBatch.created_at.desc()).all()
+    for batch in batches:
+        query = Order.query.filter_by(import_batch_id=batch.id)
+        if allowed_zones:
+            query = query.filter(Order.zone.in_(allowed_zones))
+        elif current_user.role == "courier":
+            query = query.filter(db.text("0=1"))
+        items = query.order_by(Order.id).all()
+        orders_by_batch[batch] = items
         for o in items:
             key = getattr(o, "zone", None) or "Не определена"
             orders_by_zone[key].append(o)
-            bkey = name
-            if getattr(o, "import_id", None):
-                import_ids[bkey] = str(getattr(o, "import_id"))
         all_orders.extend(items)
 
     zones_list = DeliveryZone.query.all()
@@ -385,10 +335,8 @@ def orders():
         orders=all_orders,
         orders_by_zone=orders_by_zone,
         orders_by_batch=orders_by_batch,
-        import_ids=import_ids,
         couriers=couriers_list,
         zones=zones_dict,
-        tables=order_tables,
     )
 
 
@@ -573,33 +521,18 @@ def delete_order(order_id):
     return redirect(url_for("orders"))
 
 
-@app.route("/orders/delete_batch", methods=["POST"])
+@app.route("/delete_batch/<int:batch_id>", methods=["POST"])
 @admin_required
-def delete_batch():
+def delete_batch(batch_id):
     """Delete all orders imported in the given batch."""
-    batch = request.form.get("batch")
-    if batch:
-        Order.query.filter_by(import_batch=batch).delete()
-        db.session.commit()
-        flash(f"Импорт '{batch}' удалён", "success")
+    batch = ImportBatch.query.get_or_404(batch_id)
+    Order.query.filter_by(import_batch_id=batch.id).delete()
+    db.session.delete(batch)
+    db.session.commit()
+    flash("Таблица удалена", "success")
     return redirect(url_for("orders"))
 
 
-@app.route("/orders/delete_table", methods=["POST"])
-@login_required
-def delete_table():
-    batch = request.form.get("batch")
-    if not batch:
-        flash("Не передан параметр batch", "warning")
-        return redirect(url_for("orders"))
-    inspector = inspect(db.engine)
-    if inspector.has_table("orders"):
-        Order.query.filter_by(import_batch=batch).delete()
-        db.session.commit()
-        flash(f"Таблица «{batch}» удалена", "success")
-    else:
-        flash("Таблица orders не существует", "warning")
-    return redirect(url_for("orders"))
 
 
 @app.route("/map")
@@ -1133,6 +1066,7 @@ def run_import(job_id, path, batch_name, col_map=None, header=True, clear_old=Fa
         try:
             if clear_old:
                 Order.query.delete()
+                ImportBatch.query.delete()
                 db.session.commit()
                 if db.session.bind.dialect.name == "postgresql":
                     inspector = inspect(db.engine)
@@ -1147,6 +1081,10 @@ def run_import(job_id, path, batch_name, col_map=None, header=True, clear_old=Fa
                     if seq_name:
                         db.session.execute(text(f"ALTER SEQUENCE {seq_name} RESTART WITH 1"))
                         db.session.commit()
+            batch = ImportBatch(name=batch_name)
+            db.session.add(batch)
+            db.session.commit()
+
             rows = read_file_rows(path)
             if col_map is None:
                 header = True
@@ -1205,6 +1143,7 @@ def run_import(job_id, path, batch_name, col_map=None, header=True, clear_old=Fa
                     order = Order(
                         **data,
                         import_batch=batch_name,
+                        import_batch_id=batch.id,
                         import_id=job_id,
                         local_order_number=imported + 1,
                     )

--- a/migrations/versions/e2b35c8f4c7a_add_import_batch.py
+++ b/migrations/versions/e2b35c8f4c7a_add_import_batch.py
@@ -1,0 +1,34 @@
+"""add import batch table and fk
+
+Revision ID: e2b35c8f4c7a
+Revises: a5d7000c64c3
+Create Date: 2025-07-01 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'e2b35c8f4c7a'
+down_revision = 'a5d7000c64c3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'import_batch',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+    )
+    with op.batch_alter_table('orders', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('import_batch_id', sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(None, 'import_batch', ['import_batch_id'], ['id'])
+
+
+def downgrade():
+    with op.batch_alter_table('orders', schema=None) as batch_op:
+        batch_op.drop_constraint(None, type_='foreignkey')
+        batch_op.drop_column('import_batch_id')
+    op.drop_table('import_batch')

--- a/models.py
+++ b/models.py
@@ -5,8 +5,16 @@ from flask_login import UserMixin
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.dialects.postgresql import UUID
 
-
 db = SQLAlchemy()
+
+
+class ImportBatch(db.Model):
+    __tablename__ = "import_batch"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    orders = db.relationship("Order", backref="batch", cascade="all, delete")
 
 
 class Order(db.Model):
@@ -18,6 +26,7 @@ class Order(db.Model):
     address = db.Column(db.String(256))
     note = db.Column(db.Text)
     import_batch = db.Column(db.String(64))
+    import_batch_id = db.Column(db.Integer, db.ForeignKey("import_batch.id"))
     import_id = db.Column(db.String(36), nullable=True)
     local_order_number = db.Column(db.Integer)
     status = db.Column(db.String(64), default="Складская обработка")

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -28,18 +28,17 @@
     {% for batch, lst in orders_by_batch.items() %}
     <div class="mb-2">
       <div class="d-flex justify-content-between align-items-center">
-        <h5 class="mb-0">{{ batch }}</h5>
+        <h5 class="mb-0">{{ batch.name }}{% if batch.created_at %} ({{ batch.created_at.strftime('%d.%m.%Y %H:%M') }}){% endif %}</h5>
         <div>
           {% if current_user.role == 'admin' %}
-          <form method="post" action="/orders/delete_table" class="d-inline" onsubmit="return confirm('Удалить ВСЮ таблицу?');">
-            <input type="hidden" name="batch" value="{{ batch }}">
+          <form method="post" action="{{ url_for('delete_batch', batch_id=batch.id) }}" class="d-inline" onsubmit="return confirm('Удалить ВСЮ таблицу?');">
             <button type="submit" class="btn btn-sm btn-danger">Удалить таблицу</button>
           </form>
           {% endif %}
           <a class="btn btn-sm btn-outline-secondary" data-bs-toggle="collapse" href="#collapse-{{ loop.index }}-import">Свернуть / Развернуть</a>
         </div>
       </div>
-      <div class="collapse show" id="collapse-{{ loop.index }}-import">
+      <div class="collapse" id="collapse-{{ loop.index }}-import">
         <div class="table-responsive card mt-2">
         <table class="table table-striped orders-table" id="ordersTable">
           <thead>


### PR DESCRIPTION
## Summary
- add `ImportBatch` model and link `Order.import_batch_id`
- create `ImportBatch` during import
- reorganize orders view to load batches from DB
- add `/delete_batch/<int:batch_id>` route and update templates
- keep accordions collapsed by default and show batch info
- add Alembic migration for new table and column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685950b1ce0c832c89c23da717cc19b9