### PR TITLE
Update zone creation and editing

### DIFF
--- a/app.py
+++ b/app.py
@@ -672,7 +672,17 @@ def create_zone():
         flash("Зона создана", "success")
         return redirect(url_for("zones"))
     zone = DeliveryZone(name="", color="#3388ff", polygon_json="[]")
-    return render_template("edit_zone.html", zone=zone, new=True)
+    zones = DeliveryZone.query.all()
+    zones_dict = [
+        {
+            "id": z.id,
+            "name": z.name,
+            "color": z.color,
+            "polygon": json.loads(z.polygon_json),
+        }
+        for z in zones
+    ]
+    return render_template("edit_zone.html", zone=zone, new=True, zones=zones_dict)
 
 
 @app.route("/zones/<int:zone_id>/edit", methods=["GET", "POST"])
@@ -683,7 +693,7 @@ def edit_zone(zone_id):
         zone.name = request.form.get("name", zone.name)
         zone.color = request.form.get("color", zone.color)
         polygon = request.form.get("polygon")
-        if polygon:
+        if polygon is not None:
             zone.polygon_json = polygon
         db.session.commit()
         flash("Зона обновлена", "success")

--- a/templates/edit_zone.html
+++ b/templates/edit_zone.html
@@ -34,6 +34,14 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; OpenStreetMap contributors'
 }).addTo(map);
+{% if zones %}
+var existingZones = {{ zones|tojson }};
+existingZones.forEach(function(z){
+    if(z.polygon && z.polygon.length){
+        L.polygon(z.polygon.map(function(p){ return [p[1], p[0]]; }), {color: z.color, fillOpacity: 0.05, interactive:false}).addTo(map);
+    }
+});
+{% endif %}
 
 var drawnItems = new L.FeatureGroup();
 map.addLayer(drawnItems);


### PR DESCRIPTION
## Summary
- show other zones as read-only overlays when creating a new zone
- always save polygon changes when editing

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685951c74850832cb2a2d410389e2e31