### PR TITLE
Handle WorkArea absence on map and zone pages

### DIFF
--- a/static/scripts.js
+++ b/static/scripts.js
@@ -1,5 +1,6 @@
 function initMap(orders, zones) {
   const map = L.map('map').setView([42.8746, 74.6122], 13);
+  window.appMap = map;
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; OpenStreetMap contributors'
@@ -17,10 +18,12 @@ function initMap(orders, zones) {
       marker.bindPopup(popup);
     }
   });
+  return map;
 }
 
 function initZonesMap(zones) {
   const map = L.map('zones-map').setView([42.8746, 74.6122], 12);
+  window.zonesMap = map;
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; OpenStreetMap contributors'
@@ -38,6 +41,7 @@ function initZonesMap(zones) {
   if (group.getLayers().length) {
     map.fitBounds(group.getBounds());
   }
+  return map;
 }
 document.addEventListener('DOMContentLoaded', function(){
   var modalEl = document.getElementById('setPointModal');

--- a/templates/edit_zone.html
+++ b/templates/edit_zone.html
@@ -28,7 +28,7 @@
 <script src="https://unpkg.com/leaflet-draw/dist/leaflet.draw.js"></script>
 <script>
 var existing = JSON.parse({{ zone.polygon_json|tojson|safe }});
-var workArea = {{ workarea.geojson|tojson|safe if workarea else 'null' }};
+var workArea = {{ workarea|tojson if workarea else 'null' }};
 var workColor = {{ ('"' + workarea.color + '"') if workarea else '"#777777"' }};
 var colorInput = document.getElementById('colorInput');
 var map = L.map('map').setView([42.8746, 74.6122], 12);
@@ -48,9 +48,11 @@ existingZones.forEach(function(z){
 var drawnItems = new L.FeatureGroup();
 map.addLayer(drawnItems);
 
-if (workArea && workArea.geometry && workArea.geometry.coordinates.length) {
-    var wa = L.polygon(workArea.geometry.coordinates[0].map(function(p){ return [p[1], p[0]];}), {color: workColor, interactive:false, fill:false});
-    wa.addTo(map);
+if (workArea) {
+    var waLayer = L.geoJSON({ type: 'Feature', geometry: workArea }, {
+        style: { color: workColor, weight: 2, fillOpacity: 0.05, dashArray: '5 5' }
+    }).addTo(map);
+    map.fitBounds(waLayer.getBounds());
 }
 
 if (existing.length) {

--- a/templates/map.html
+++ b/templates/map.html
@@ -11,8 +11,15 @@
 <script>
 var orders = {{ orders|tojson }};
 var zones = {{ zones|tojson }};
+var workarea = {{ workarea|tojson if workarea else 'null' }};
 window.addEventListener('DOMContentLoaded', function(){
-  initMap(orders, zones);
+  var map = initMap(orders, zones);
+  if (workarea) {
+      var waLayer = L.geoJSON({ type: 'Feature', geometry: workarea }, {
+          style: { color: '#777', weight: 2, fillOpacity: 0.05, dashArray: '5 5' }
+      }).addTo(map);
+      map.fitBounds(waLayer.getBounds());
+  }
 });
 </script>
 {% endblock %}

--- a/templates/zones.html
+++ b/templates/zones.html
@@ -32,7 +32,14 @@
 <script>
 window.addEventListener('DOMContentLoaded', function(){
   var zones = {{ zones|tojson }};
-  initZonesMap(zones);
+  var workarea = {{ workarea|tojson if workarea else 'null' }};
+  var map = initZonesMap(zones);
+  if (workarea) {
+      var waLayer = L.geoJSON({ type: 'Feature', geometry: workarea }, {
+          style: { color: '#777', weight: 2, fillOpacity: 0.05, dashArray: '5 5' }
+      }).addTo(map);
+      map.fitBounds(waLayer.getBounds());
+  }
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- fix `/zones` and `/map` views to provide work area GeoJSON
- validate zone polygons stay inside work area
- expose created map objects from JS helpers
- display work area layer in map and zone templates
- adjust edit zone template to use GeoJSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859723fcc14832c975fd9b729abf41c