### PR TITLE
Fix crashes when work area absent

### DIFF
--- a/templates/edit_zone.html
+++ b/templates/edit_zone.html
@@ -29,7 +29,7 @@
 <script>
 var existing = JSON.parse({{ zone.polygon_json|tojson|safe }});
 var workArea = {{ workarea|tojson if workarea else 'null' }};
-var workColor = {{ ('"' + workarea.color + '"') if workarea else '"#777777"' }};
+var workColor = {{ '"' + workcolor + '"' }};
 var colorInput = document.getElementById('colorInput');
 var map = L.map('map').setView([42.8746, 74.6122], 12);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {

--- a/templates/workarea/index.html
+++ b/templates/workarea/index.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet-draw/dist/leaflet.draw.css" />
 <script src="https://unpkg.com/leaflet-draw/dist/leaflet.draw.js"></script>
 <script>
-var existing = {{ area.geojson|tojson|safe }};
+var existing = JSON.parse({{ area.geojson|tojson|safe }});
 var colorInput = document.getElementById('colorInput');
 var map = L.map('map').setView([42.8746, 74.6122], 12);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom:19, attribution:'&copy; OpenStreetMap contributors'}).addTo(map);


### PR DESCRIPTION
## Summary
- prevent crashes on `/map` and `/zones` when there is no work area
- show work area polygon when editing zones
- load existing work area polygon on edit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685989b23bb0832ca502be832173049b