### PR TITLE
Fix zone creation link and unify edit handler

### DIFF
--- a/templates/zones.html
+++ b/templates/zones.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Зоны доставки</h2>
-<a class="btn btn-primary mb-3" href="{{ url_for('new_zone') }}">Создать зону</a>
+<a class="btn btn-primary mb-3" href="{{ url_for('edit_zone', new=True) }}">Создать зону</a>
 <div class="table-responsive card">
 <table class="table table-striped mb-3">
     <thead>


### PR DESCRIPTION
## Summary
- consolidate edit_zone route to handle new zones via `/zones/new`
- link 'Create zone' button to the edit_zone endpoint with `new=True`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685994ec5bc8832cb07083841fc4cedc