### PR TITLE
Fix orders and zone display

### DIFF
--- a/models.py
+++ b/models.py
@@ -14,7 +14,6 @@ class ImportBatch(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    orders = db.relationship("Order", backref="batch", cascade="all, delete")
 
 
 class Order(db.Model):
@@ -26,10 +25,6 @@ class Order(db.Model):
     address = db.Column(db.String(256))
     note = db.Column(db.Text)
     import_batch = db.Column(db.String(64))
-    import_batch_id = db.Column(
-        db.Integer, db.ForeignKey("import_batch.id"), nullable=True
-    )
-    import_id = db.Column(db.String(36), nullable=True)
     local_order_number = db.Column(db.Integer)
     status = db.Column(db.String(64), default="Складская обработка")
     latitude = db.Column(db.Float)


### PR DESCRIPTION
## Summary
- remove `import_id` and `import_batch_id` from `Order`
- drop unused `ImportBatch.orders` relation
- load polygons in Python with safety checks
- return only geometry for `WorkArea` on map and zones pages
- adjust importer accordingly

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a2005fc4832c8fe4126640c182c2