### PR TITLE
Add import_batch_id column with migration

### DIFF
--- a/migrations/versions/fedcba987654_add_import_batch_id_to_orders.py
+++ b/migrations/versions/fedcba987654_add_import_batch_id_to_orders.py
@@ -1,0 +1,27 @@
+"""Add import_batch_id to orders
+
+Revision ID: fedcba987654
+Revises: 850c1a5add64
+Create Date: 2025-07-05 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'fedcba987654'
+down_revision = '850c1a5add64'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('orders', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('import_batch_id', sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(None, 'import_batch', ['import_batch_id'], ['id'])
+
+
+def downgrade():
+    with op.batch_alter_table('orders', schema=None) as batch_op:
+        batch_op.drop_constraint(None, type_='foreignkey')
+        batch_op.drop_column('import_batch_id')

--- a/models.py
+++ b/models.py
@@ -25,6 +25,7 @@ class Order(db.Model):
     address = db.Column(db.String(256))
     note = db.Column(db.Text)
     import_batch = db.Column(db.String(64))
+    import_batch_id = db.Column(db.Integer, db.ForeignKey("import_batch.id"), nullable=True)
     local_order_number = db.Column(db.Integer)
     status = db.Column(db.String(64), default="Складская обработка")
     latitude = db.Column(db.Float)


### PR DESCRIPTION
## Summary
- add `import_batch_id` column to `Order`
- provide alembic migration for `import_batch_id`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859faed48c8832ca5841918caabf0ca