### PR TITLE
Fix missing import_batch_label column

### DIFF
--- a/migrations/versions/9b3b39c284f0_add_import_batch_label.py
+++ b/migrations/versions/9b3b39c284f0_add_import_batch_label.py
@@ -1,0 +1,24 @@
+"""Add import_batch_label column
+
+Revision ID: 9b3b39c284f0
+Revises: f280d8488846
+Create Date: 2025-07-20 00:00:00
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '9b3b39c284f0'
+down_revision = 'f280d8488846'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TABLE orders ADD COLUMN IF NOT EXISTS import_batch_label VARCHAR(128);")
+
+
+def downgrade():
+    op.execute("ALTER TABLE orders DROP COLUMN IF EXISTS import_batch_label;")
+

--- a/models.py
+++ b/models.py
@@ -25,7 +25,7 @@ class Order(db.Model):
     address = db.Column(db.String(256))
     note = db.Column(db.Text)
     import_batch_id = db.Column(db.Integer, db.ForeignKey("import_batch.id"))
-    import_batch_label = db.Column(db.String)
+    import_batch_label = db.Column(db.String(128))
     local_order_number = db.Column(db.Integer)
     status = db.Column(db.String(64), default="Складская обработка")
     latitude = db.Column(db.Float)


### PR DESCRIPTION
## Summary
- store import batch label in `Order` model with length limit
- add Alembic migration to create the column via raw SQL

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac529d95c832c9a9d1739636d71b2