### PR TITLE
Enable work area editing on zones page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -22,7 +22,7 @@
       {% endif %}
       {% if current_user.role == 'admin' %}
       <li><a class="nav-link" href="{{ url_for('zones') }}">Зоны доставки</a></li>
-      <li><a class="nav-link" href="{{ url_for('workarea') }}">Рабочая область</a></li>
+      <li><a class="nav-link" href="{{ url_for('work_area_page') }}">Рабочая область</a></li>
       <li><a class="nav-link" href="{{ url_for('users') }}">Пользователи</a></li>
       <li><a class="nav-link" href="{{ url_for('stats') }}">Статистика</a></li>
       <li><a class="nav-link" href="{{ url_for('reports') }}">Отчёты</a></li>
@@ -63,7 +63,7 @@
         {% endif %}
         {% if current_user.role == 'admin' %}
         <li><a class="nav-link" href="{{ url_for('zones') }}">Зоны доставки</a></li>
-        <li><a class="nav-link" href="{{ url_for('workarea') }}">Рабочая область</a></li>
+        <li><a class="nav-link" href="{{ url_for('work_area_page') }}">Рабочая область</a></li>
         <li><a class="nav-link" href="{{ url_for('users') }}">Пользователи</a></li>
         <li><a class="nav-link" href="{{ url_for('stats') }}">Статистика</a></li>
         <li><a class="nav-link" href="{{ url_for('reports') }}">Отчёты</a></li>

--- a/templates/work_area.html
+++ b/templates/work_area.html
@@ -1,0 +1,45 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Рабочая область</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Цвет</label>
+    <input type="color" class="form-control form-control-color" id="colorInput" name="color" value="{{ area.color }}">
+  </div>
+  <div id="map" style="height:500px;" class="mb-3"></div>
+  <input type="hidden" name="geojson" id="geojsonInput">
+  <button type="submit" class="btn btn-primary">Сохранить</button>
+</form>
+{% endblock %}
+{% block scripts %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
+<script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/leaflet.pm/dist/leaflet.pm.css" />
+<script src="https://unpkg.com/leaflet.pm/dist/leaflet.pm.min.js"></script>
+<script>
+var work = {{ workarea|tojson if workarea else 'null' }};
+var colorInput = document.getElementById('colorInput');
+var map = L.map('map').setView([42.8746, 74.6122], 12);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom:19, attribution:'&copy; OpenStreetMap contributors'}).addTo(map);
+map.pm.addControls({ drawCircle:false, drawMarker:false, drawPolyline:false, drawCircleMarker:false, drawRectangle:false });
+var layer = null;
+if (work) {
+  const geo = L.geoJSON({ type: 'Feature', geometry: work }, { color: colorInput.value }).addTo(map);
+  geo.eachLayer(function(l){ layer = l; l.pm.enable(); });
+  map.fitBounds(geo.getBounds());
+}
+function updateGeo(){
+  var gj = null;
+  if(layer){
+    layer.setStyle({color: colorInput.value});
+    gj = layer.toGeoJSON().geometry;
+  }
+  document.getElementById('geojsonInput').value = JSON.stringify(gj);
+}
+map.on('pm:create', function(e){ if(layer) map.removeLayer(layer); layer = e.layer; layer.pm.enable(); updateGeo(); });
+map.on('pm:update', updateGeo);
+map.on('pm:remove', function(){ layer = null; updateGeo(); });
+colorInput.addEventListener('change', updateGeo);
+updateGeo();
+</script>
+{% endblock %}

--- a/templates/zones.html
+++ b/templates/zones.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h2>Зоны доставки</h2>
 <a class="btn btn-primary mb-3" href="{{ url_for('edit_zone', new=True) }}">Создать зону</a>
-<button class="btn btn-secondary mb-3 ms-2" data-bs-toggle="modal" data-bs-target="#workAreaModal">Редактировать рабочую область</button>
+<button class="btn btn-secondary mb-3 ms-2" data-bs-toggle="modal" data-bs-target="#workAreaModal">Изменить рабочую область</button>
 <div class="table-responsive card">
 <table class="table table-striped mb-3">
     <thead>
@@ -84,7 +84,7 @@ window.addEventListener('DOMContentLoaded', function(){
 
   document.getElementById('saveWorkAreaBtn').addEventListener('click', function(){
       var gj=null; if(waLayer){ gj=waLayer.toGeoJSON().geometry; }
-      fetch('/api/workarea', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({color: document.getElementById('waColor').value, geojson: JSON.stringify(gj)})})
+      fetch('/work-area/save', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({color: document.getElementById('waColor').value, geojson: JSON.stringify(gj)})})
         .then(function(r){ if(r.ok) location.reload(); });
   });
 });


### PR DESCRIPTION
## Summary
- add helpers for replacing work area
- implement `/work-area` page and `/work-area/save` endpoint
- update navigation links to new route
- show "Изменить рабочую область" button on zones page and send data to new endpoint
- provide dedicated `work_area.html` template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b27242b74832c939bfc173755ccf3