### PR TITLE
Enable editing saved work area

### DIFF
--- a/templates/work_area.html
+++ b/templates/work_area.html
@@ -8,7 +8,7 @@
   </div>
   <div id="map" style="height:500px;" class="mb-3"></div>
   <input type="hidden" name="geojson" id="geojsonInput">
-  <button type="submit" class="btn btn-primary">Сохранить</button>
+  <button type="submit" class="btn btn-primary">{{ 'Сохранить изменения' if exists else 'Сохранить' }}</button>
 </form>
 {% endblock %}
 {% block scripts %}
@@ -34,7 +34,8 @@ function updateGeo(){
     layer.setStyle({color: colorInput.value});
     gj = layer.toGeoJSON().geometry;
   }
-  document.getElementById('geojsonInput').value = JSON.stringify(gj);
+  var val = gj ? {type:'Feature', geometry: gj} : null;
+  document.getElementById('geojsonInput').value = JSON.stringify(val);
 }
 map.on('pm:create', function(e){ if(layer) map.removeLayer(layer); layer = e.layer; layer.pm.enable(); updateGeo(); });
 map.on('pm:update', updateGeo);

--- a/templates/workarea/index.html
+++ b/templates/workarea/index.html
@@ -8,7 +8,7 @@
   </div>
   <div id="map" style="height:500px;" class="mb-3"></div>
   <input type="hidden" name="geojson" id="geojsonInput">
-  <button type="submit" class="btn btn-primary">Сохранить</button>
+  <button type="submit" class="btn btn-primary">{{ 'Сохранить изменения' if exists else 'Сохранить' }}</button>
 </form>
 {% endblock %}
 {% block scripts %}
@@ -34,7 +34,8 @@ function updateGeo(){
     layer.setStyle({color: colorInput.value});
     gj = layer.toGeoJSON().geometry;
   }
-  document.getElementById('geojsonInput').value = JSON.stringify(gj);
+  var val = gj ? {type:'Feature', geometry: gj} : null;
+  document.getElementById('geojsonInput').value = JSON.stringify(val);
 }
 map.on('pm:create', function(e){ if(layer) map.removeLayer(layer); layer = e.layer; layer.pm.enable(); updateGeo(); });
 map.on('pm:update', updateGeo);

--- a/templates/zones.html
+++ b/templates/zones.html
@@ -84,7 +84,8 @@ window.addEventListener('DOMContentLoaded', function(){
 
   document.getElementById('saveWorkAreaBtn').addEventListener('click', function(){
       var gj=null; if(waLayer){ gj=waLayer.toGeoJSON().geometry; }
-      fetch('/work-area/save', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({color: document.getElementById('waColor').value, geojson: JSON.stringify(gj)})})
+      var val = gj ? {type:'Feature', geometry: gj} : null;
+      fetch('/work-area/save', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({color: document.getElementById('waColor').value, geojson: JSON.stringify(val)})})
         .then(function(r){ if(r.ok) location.reload(); });
   });
 });


### PR DESCRIPTION
## Summary
- allow reloading editable polygon when editing work area
- wrap geometry in GeoJSON Feature when saving
- adjust templates to send wrapped geojson
- show `Сохранить изменения` when area already exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b34fa791c832cacc1626808600093