### PR TITLE
Add work area checks for zones

### DIFF
--- a/templates/zones.html
+++ b/templates/zones.html
@@ -1,7 +1,10 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Зоны доставки</h2>
-<a class="btn btn-primary mb-3" href="{{ url_for('edit_zone', new=True) }}">Создать зону</a>
+{% if not wa_exists %}
+<div class="alert alert-warning">Сначала задайте рабочую область</div>
+{% endif %}
+<a class="btn btn-primary mb-3{% if not wa_exists %} disabled{% endif %}" href="{% if wa_exists %}{{ url_for('edit_zone', new=True) }}{% else %}#{% endif %}">Создать зону</a>
 <div class="table-responsive card">
 <table class="table table-striped mb-3">
     <thead>


### PR DESCRIPTION
## Summary
- disable zone creation when no work area is defined
- validate presence of work area before editing or adding a zone

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3b2f49f0832c8a6c70283f241b7f