### PR TITLE
Enable geometry editing for work area

### DIFF
--- a/templates/work_area.html
+++ b/templates/work_area.html
@@ -7,7 +7,7 @@
     <input type="color" class="form-control form-control-color" id="colorInput" name="color" value="{{ area.color }}">
   </div>
   <div id="map" style="height:500px;" class="mb-3"></div>
-  <input type="hidden" name="geojson" id="geojsonInput">
+  <input type="hidden" name="geometry" id="geometryInput">
   <button type="submit" class="btn btn-primary">{{ 'Сохранить изменения' if exists else 'Сохранить' }}</button>
 </form>
 {% endblock %}
@@ -25,7 +25,12 @@ map.pm.addControls({ drawCircle:false, drawMarker:false, drawPolyline:false, dra
 var layer = null;
 if (work) {
   const geo = L.geoJSON({ type: 'Feature', geometry: work }, { color: colorInput.value }).addTo(map);
-  geo.eachLayer(function(l){ layer = l; l.pm.enable(); });
+  geo.eachLayer(function(l){
+    layer = l;
+    l.pm.enable();
+    l.on('pm:edit', updateGeo);
+    l.on('pm:dragend', updateGeo);
+  });
   map.fitBounds(geo.getBounds());
 }
 function updateGeo(){
@@ -35,9 +40,16 @@ function updateGeo(){
     gj = layer.toGeoJSON().geometry;
   }
   var val = gj ? {type:'Feature', geometry: gj} : null;
-  document.getElementById('geojsonInput').value = JSON.stringify(val);
+  document.getElementById('geometryInput').value = JSON.stringify(val);
 }
-map.on('pm:create', function(e){ if(layer) map.removeLayer(layer); layer = e.layer; layer.pm.enable(); updateGeo(); });
+map.on('pm:create', function(e){
+  if(layer) map.removeLayer(layer);
+  layer = e.layer;
+  layer.pm.enable();
+  layer.on('pm:edit', updateGeo);
+  layer.on('pm:dragend', updateGeo);
+  updateGeo();
+});
 map.on('pm:update', updateGeo);
 map.on('pm:remove', function(){ layer = null; updateGeo(); });
 colorInput.addEventListener('change', updateGeo);

--- a/templates/workarea/index.html
+++ b/templates/workarea/index.html
@@ -7,7 +7,7 @@
     <input type="color" class="form-control form-control-color" id="colorInput" name="color" value="{{ area.color }}">
   </div>
   <div id="map" style="height:500px;" class="mb-3"></div>
-  <input type="hidden" name="geojson" id="geojsonInput">
+  <input type="hidden" name="geometry" id="geometryInput">
   <button type="submit" class="btn btn-primary">{{ 'Сохранить изменения' if exists else 'Сохранить' }}</button>
 </form>
 {% endblock %}
@@ -25,7 +25,12 @@ map.pm.addControls({ drawCircle:false, drawMarker:false, drawPolyline:false, dra
 var layer = null;
 if (work) {
   const geo = L.geoJSON({ type: 'Feature', geometry: work }, { color: colorInput.value }).addTo(map);
-  geo.eachLayer(function(l){ layer = l; l.pm.enable(); });
+  geo.eachLayer(function(l){
+    layer = l;
+    l.pm.enable();
+    l.on('pm:edit', updateGeo);
+    l.on('pm:dragend', updateGeo);
+  });
   map.fitBounds(geo.getBounds());
 }
 function updateGeo(){
@@ -35,9 +40,16 @@ function updateGeo(){
     gj = layer.toGeoJSON().geometry;
   }
   var val = gj ? {type:'Feature', geometry: gj} : null;
-  document.getElementById('geojsonInput').value = JSON.stringify(val);
+  document.getElementById('geometryInput').value = JSON.stringify(val);
 }
-map.on('pm:create', function(e){ if(layer) map.removeLayer(layer); layer = e.layer; layer.pm.enable(); updateGeo(); });
+map.on('pm:create', function(e){
+  if(layer) map.removeLayer(layer);
+  layer = e.layer;
+  layer.pm.enable();
+  layer.on('pm:edit', updateGeo);
+  layer.on('pm:dragend', updateGeo);
+  updateGeo();
+});
 map.on('pm:update', updateGeo);
 map.on('pm:remove', function(){ layer = null; updateGeo(); });
 colorInput.addEventListener('change', updateGeo);


### PR DESCRIPTION
## Summary
- allow editing existing work area
- store geometry in `geometry` hidden input
- update work area persistence logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c1ce9ea50832cb6db9f7a8c4e56ee