### PR TITLE
Display zones on main map

### DIFF
--- a/app.py
+++ b/app.py
@@ -772,6 +772,7 @@ def zones():
 
     zones = DeliveryZone.query.all()
     zones_dict = []
+    zones_geo = []
     for z in zones:
         try:
             poly = json.loads(z.polygon_json) if z and z.polygon_json else []
@@ -784,12 +785,27 @@ def zones():
             "polygon": poly,
         })
 
+        zone_gj = None
+        if z.geometry:
+            try:
+                zone_gj = json.loads(z.geometry)
+            except Exception:
+                zone_gj = None
+        if not zone_gj:
+            zone_gj = {"type": "Feature", "geometry": {"type": "Polygon", "coordinates": [poly]}}
+        if isinstance(zone_gj, dict) and zone_gj.get("type") == "Feature":
+            geometry = zone_gj.get("geometry")
+        else:
+            geometry = zone_gj
+        zones_geo.append({"name": z.name, "color": z.color, "geometry": geometry})
+
     return render_template(
         "zones.html",
         zones=zones_dict,
         workarea=wa_json,
         workcolor=work_color,
         wa_exists=wa_exists,
+        zones_geo=zones_geo,
     )
 
 

--- a/static/js/zones_map.js
+++ b/static/js/zones_map.js
@@ -5,28 +5,28 @@ window.addEventListener('DOMContentLoaded', () => {
     attribution: '&copy; OpenStreetMap contributors'
   }).addTo(map);
 
-  Promise.all([
-    fetch('/api/zones').then(r => r.json()),
-    fetch('/api/work-area').then(r => r.json())
-  ]).then(([zones, workArea]) => {
-    const group = L.featureGroup().addTo(map);
-    if (zones && zones.features) {
-      zones.features.forEach(f => {
-        const layer = L.geoJSON(f, {
-          style: { color: f.properties.color }
+  const group = L.featureGroup().addTo(map);
+
+  if (window.deliveryZones && window.deliveryZones.length) {
+    window.deliveryZones.forEach(zone => {
+      if (zone.geometry) {
+        const layer = L.geoJSON({ type: 'Feature', geometry: zone.geometry }, {
+          style: { color: zone.color }
         });
-        layer.bindPopup(f.properties.name);
+        layer.bindPopup(zone.name);
         group.addLayer(layer);
-      });
-    }
-    if (workArea && workArea.geometry) {
-      const waLayer = L.geoJSON(workArea, {
-        style: { color: '#777777', weight: 1, fillOpacity: 0.2, dashArray: '5 5' }
-      });
-      group.addLayer(waLayer);
-    }
-    if (group.getLayers().length) {
-      map.fitBounds(group.getBounds());
-    }
-  });
+      }
+    });
+  }
+
+  if (window.workArea && window.workArea.geometry) {
+    const waLayer = L.geoJSON(window.workArea, {
+      style: { color: '#888888', opacity: 0.2, fillOpacity: 0.1 }
+    });
+    group.addLayer(waLayer);
+  }
+
+  if (group.getLayers().length) {
+    map.fitBounds(group.getBounds());
+  }
 });

--- a/templates/zones.html
+++ b/templates/zones.html
@@ -34,5 +34,13 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
 <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
 <script src="https://unpkg.com/@turf/turf@6.5.0/turf.min.js"></script>
+<script>
+  window.deliveryZones = {{ zones_geo|tojson }};
+  {% if workarea %}
+  window.workArea = {{ {'geometry': workarea}|tojson }};
+  {% else %}
+  window.workArea = null;
+  {% endif %}
+</script>
 <script src="{{ url_for('static', filename='js/zones_map.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- render existing zones and work area directly on the Zones page
- expose zone/work area data as global variables
- draw zones and work area on map after page load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c210bec80832ca4a9e8badbb64029