### PR TITLE
Display zones via API on map

### DIFF
--- a/app.py
+++ b/app.py
@@ -762,7 +762,6 @@ def get_zones():
 def zones():
     work_area = WorkArea.query.first()
     wa_json = _get_work_area_json(work_area)
-    work_color = work_area.color if work_area else "#777777"
     wa_exists = bool(
         wa_json
         and isinstance(wa_json, dict)
@@ -772,7 +771,6 @@ def zones():
 
     zones = DeliveryZone.query.all()
     zones_dict = []
-    zones_geo = []
     for z in zones:
         try:
             poly = json.loads(z.polygon_json) if z and z.polygon_json else []
@@ -785,27 +783,10 @@ def zones():
             "polygon": poly,
         })
 
-        zone_gj = None
-        if z.geometry:
-            try:
-                zone_gj = json.loads(z.geometry)
-            except Exception:
-                zone_gj = None
-        if not zone_gj:
-            zone_gj = {"type": "Feature", "geometry": {"type": "Polygon", "coordinates": [poly]}}
-        if isinstance(zone_gj, dict) and zone_gj.get("type") == "Feature":
-            geometry = zone_gj.get("geometry")
-        else:
-            geometry = zone_gj
-        zones_geo.append({"name": z.name, "color": z.color, "geometry": geometry})
-
     return render_template(
         "zones.html",
         zones=zones_dict,
-        workarea=wa_json,
-        workcolor=work_color,
         wa_exists=wa_exists,
-        zones_geo=zones_geo,
     )
 
 

--- a/static/js/zones_map.js
+++ b/static/js/zones_map.js
@@ -7,26 +7,36 @@ window.addEventListener('DOMContentLoaded', () => {
 
   const group = L.featureGroup().addTo(map);
 
-  if (window.deliveryZones && window.deliveryZones.length) {
-    window.deliveryZones.forEach(zone => {
-      if (zone.geometry) {
-        const layer = L.geoJSON({ type: 'Feature', geometry: zone.geometry }, {
-          style: { color: zone.color }
+  Promise.all([
+    fetch('/api/zones').then(r => r.json()),
+    fetch('/api/work-area').then(r => r.json())
+  ]).then(([zones, workArea]) => {
+    if (zones && zones.features) {
+      zones.features.forEach(feature => {
+        const layer = L.geoJSON(feature, {
+          style: { color: feature.properties.color }
         });
-        layer.bindPopup(zone.name);
+        if (feature.properties.name) {
+          layer.bindTooltip(feature.properties.name, { permanent: false });
+        }
         group.addLayer(layer);
-      }
-    });
-  }
+      });
+    }
 
-  if (window.workArea && window.workArea.geometry) {
-    const waLayer = L.geoJSON(window.workArea, {
-      style: { color: '#888888', opacity: 0.2, fillOpacity: 0.1 }
-    });
-    group.addLayer(waLayer);
-  }
+    if (workArea && workArea.geometry) {
+      const waLayer = L.geoJSON(workArea, {
+        style: {
+          color: '#555',
+          fillOpacity: 0.05,
+          dashArray: '4',
+          weight: 1
+        }
+      });
+      group.addLayer(waLayer);
+    }
 
-  if (group.getLayers().length) {
-    map.fitBounds(group.getBounds());
-  }
+    if (group.getLayers().length) {
+      map.fitBounds(group.getBounds());
+    }
+  });
 });

--- a/templates/zones.html
+++ b/templates/zones.html
@@ -34,13 +34,5 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
 <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
 <script src="https://unpkg.com/@turf/turf@6.5.0/turf.min.js"></script>
-<script>
-  window.deliveryZones = {{ zones_geo|tojson }};
-  {% if workarea %}
-  window.workArea = {{ {'geometry': workarea}|tojson }};
-  {% else %}
-  window.workArea = null;
-  {% endif %}
-</script>
 <script src="{{ url_for('static', filename='js/zones_map.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- update `/zones` route to only return zone table data and flag about work area
- load zone polygons and work area via `/api/*` in `zones_map.js`
- simplify page template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c2592f4c0832c833ef69ff6dd8db9