### PR TITLE
Implement map-based zone editing

### DIFF
--- a/app.py
+++ b/app.py
@@ -887,6 +887,9 @@ def edit_zone(zone_id=None):
             elif obj.get("geometry") and obj["geometry"].get("type") == "Polygon":
                 coords = obj["geometry"].get("coordinates", [])
         polygon_coords = coords[0] if coords else []
+        if not polygon_coords:
+            flash("Нарисуйте зону на карте", "danger")
+            return redirect(request.url)
         zone_geo = {
             "type": "Feature",
             "geometry": {"type": "Polygon", "coordinates": coords},
@@ -947,7 +950,7 @@ def edit_zone(zone_id=None):
             zone_geojson = None
 
     return render_template(
-        "zone_form.html",
+        "zones/edit_zone.html",
         zone=zone,
         new=new,
         zones=zones_dict,

--- a/templates/zones/edit_zone.html
+++ b/templates/zones/edit_zone.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% block content %}
+{% if new %}
+<h2>Создание зоны</h2>
+{% else %}
+<h2>Редактирование зоны {{ zone.name }}</h2>
+{% endif %}
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Название</label>
+    <input type="text" class="form-control" name="name" value="{{ zone.name }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Цвет</label>
+    <input type="color" class="form-control form-control-color" id="colorInput" name="color" value="{{ zone.color }}">
+  </div>
+  <div id="zoneMap" style="height: 500px;"></div>
+  <p class="form-text text-muted">Используйте инструменты на карте для создания или редактирования границ зоны</p>
+  <input type="hidden" name="geojson" id="geojsonInput">
+  <input type="hidden" name="geometry" id="geometry-input">
+  <button type="submit" class="btn btn-primary">Сохранить</button>
+  <a href="{{ url_for('zones') }}" class="btn btn-secondary">Отмена</a>
+</form>
+{% endblock %}
+{% block scripts %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
+<script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/leaflet-draw/dist/leaflet.draw.css" />
+<script src="https://cdn.jsdelivr.net/npm/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
+<script src="https://unpkg.com/@turf/turf@6.5.0/turf.min.js"></script>
+<script>
+  window.existingZone = {{ zone_geojson|tojson if zone_geojson else 'null' }};
+  window.zoneId = {{ zone.id if not new else 'null' }};
+</script>
+<script src="{{ url_for('static', filename='js/zone_form_map.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- render new template `zones/edit_zone.html` for zone creation/editing
- validate polygon is provided before saving
- show map editing help

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c7452eda8832c849cf4a9d3d55b16