### PR TITLE
Fix /orders page to show all batches

### DIFF
--- a/app.py
+++ b/app.py
@@ -326,11 +326,8 @@ def orders():
 
     batch_filter = request.args.get("batch")
     batches = ImportBatch.query.order_by(ImportBatch.created_at.desc()).all()
-    if batch_filter != "all":
-        if not batch_filter and batches:
-            batch_filter = batches[0].name
-        if batch_filter:
-            batches = [b for b in batches if b.name == batch_filter]
+    if batch_filter and batch_filter != "all":
+        batches = [b for b in batches if b.name == batch_filter]
 
     if batches:
         for batch in batches:
@@ -374,6 +371,7 @@ def orders():
         orders=all_orders,
         orders_by_zone=orders_by_zone,
         orders_by_batch=orders_by_batch,
+        import_batches=batches,
         couriers=couriers_list,
         zones=zones_dict,
     )

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -25,7 +25,8 @@
 </ul>
 <div class="tab-content">
   <div class="tab-pane fade show active" id="tabAll">
-    {% for batch, lst in orders_by_batch.items() %}
+    {% for batch in import_batches %}
+    {% set lst = orders_by_batch[batch] %}
     <div class="mb-2">
       <div class="d-flex justify-content-between align-items-center">
         <h5 class="mb-0">{{ batch.name }}{% if batch.created_at %} ({{ batch.created_at.strftime('%d.%m.%Y %H:%M') }}){% endif %}</h5>


### PR DESCRIPTION
## Summary
- ensure `/orders` doesn't default to the latest batch
- expose batches list to the template
- iterate through batches in orders page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c7fabcc28832c991bbd79e2e887bb